### PR TITLE
Round 7 주문/좋아요 관련 이벤트 처리

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/event/DataPlatformEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/event/DataPlatformEventHandler.java
@@ -1,0 +1,38 @@
+package com.loopers.application.event;
+
+import com.loopers.infrastructure.dataplatform.DataPlatformClient;
+import com.loopers.interfaces.listener.order.OrderCompletedEvent;
+import com.loopers.interfaces.listener.payment.PaymentFailEvent;
+import com.loopers.interfaces.listener.payment.PaymentSuccessEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DataPlatformEventHandler {
+
+    private final DataPlatformClient dataPlatformClient;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleOrderCompleted(OrderCompletedEvent event) {
+        log.info("주문 성공 dataPlatform 호출");
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handlePaymentSuccess(PaymentSuccessEvent event) {
+        log.info("결제 성공 dataPlatform 호출");
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handlePaymentFailed(PaymentFailEvent event) {
+        log.info("결제 실패 dataPlatform 호출");
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -34,7 +34,7 @@ public class LikeFacade {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 정보가 없습니다.");
         }
 
-        Optional<ProductEntity> optionalProductEntity = productService.getProductInfoWithLock(productId);
+        Optional<ProductEntity> optionalProductEntity = productService.getProductInfo(productId);
         if (optionalProductEntity.isEmpty()) {
             throw new CoreException(GlobalErrorType.NOT_FOUND, "상품 정보가 없습니다.");
         }
@@ -55,7 +55,7 @@ public class LikeFacade {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 정보가 없습니다.");
         }
 
-        Optional<ProductEntity> optionalProductEntity = productService.getProductInfoWithLock(productId);
+        Optional<ProductEntity> optionalProductEntity = productService.getProductInfo(productId);
         if (optionalProductEntity.isEmpty()) {
             throw new CoreException(GlobalErrorType.NOT_FOUND, "상품 정보가 없습니다.");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -40,6 +40,7 @@ public class LikeFacade {
         }
 
         LikeEntity likeEntity = likeService.like(optionalUserEntity.get(), optionalProductEntity.get());
+
         return LikeInfo.from(likeEntity, optionalUserEntity.get(), optionalProductEntity.get());
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -12,9 +12,12 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.order.OrderV1Dto;
+import com.loopers.interfaces.listener.coupon.UserCouponUseEvent;
+import com.loopers.interfaces.listener.payment.PaymentCreateEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,9 +37,12 @@ public class OrderFacade {
     private final OrderDomainService orderDomainService;
     private final UserCouponService userCouponService;
     private final PaymentService paymentService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public OrderInfo order(String userId, OrderV1Dto.OrderRequest request) {
+//        OrderEntity orderEntity = orderService.order(userId, request);
+
         // 1. 사용자 정보 확인
         if (userId == null) {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 ID 정보가 없습니다.");
@@ -53,7 +59,6 @@ public class OrderFacade {
         UserEntity user = userService.getUserInfoWithLock(userId).orElseThrow(() -> new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
         Long totalPrice = orderDomainService.calculateTotalPrice(itemList);
 
-
         // 4. 쿠폰 확인
         UserCouponEntity userCoupon = null;
         if (request.couponId() != null) {
@@ -67,18 +72,25 @@ public class OrderFacade {
             throw new CoreException(GlobalErrorType.BAD_REQUEST, "상품 총 합계와 주문 금액이 일치하지 않습니다.");
         }
 
-        // 6. 쿠폰 사용
-        if (userCoupon != null) {
-            userCouponDomainService.useCoupon(userCoupon, calculatePrice);
+        // 6. 주문
+        OrderEntity orderEntity = orderService.createOrder(user, itemList, calculatePrice, userCoupon);
+        paymentService.addPaymentToOrder(orderEntity, request.payment().method(), request.payment().cardId());
+        orderEntity = orderService.saveOrder(orderEntity);
+
+        // 7. 쿠폰 사용
+        if (orderEntity.getUserCoupon() != null) {
+            eventPublisher.publishEvent(new UserCouponUseEvent(orderEntity.getPayment().getId(), orderEntity.getUserCoupon().getId(), orderEntity.getTotalPrice()));
         }
 
-        // 7. 주문
-        OrderEntity orderEntity = orderService.order(user, itemList, calculatePrice, userCoupon);
-        paymentService.addPaymentToOrder(orderEntity, request.payment().method(), request.payment().cardId());
-
         // 8. 결제
-        Boolean result = paymentService.payment(user, orderEntity);
-        return OrderInfo.from(orderEntity, result);
+        eventPublisher.publishEvent(new PaymentCreateEvent(
+                orderEntity.getUser().getId(),
+                orderEntity.getPayment().getId(),
+                orderEntity.getUuid(),
+                orderEntity.getPayment().getMethod(),
+                orderEntity.getId()
+        ));
+        return OrderInfo.from(orderEntity);
     }
 
     public List<OrderInfo> getUserOrderInfoList(String userId, LocalDate startDate, LocalDate endDate, Integer page, Integer size) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -13,6 +13,7 @@ import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.order.OrderV1Dto;
 import com.loopers.interfaces.listener.coupon.UserCouponUseEvent;
+import com.loopers.interfaces.listener.dataplatform.DataPlatformSendEvent;
 import com.loopers.interfaces.listener.payment.PaymentCreateEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
@@ -79,7 +80,7 @@ public class OrderFacade {
 
         // 7. 쿠폰 사용
         if (orderEntity.getUserCoupon() != null) {
-            eventPublisher.publishEvent(new UserCouponUseEvent(orderEntity.getPayment().getId(), orderEntity.getUserCoupon().getId(), orderEntity.getTotalPrice()));
+            eventPublisher.publishEvent(new UserCouponUseEvent(orderEntity.getPayment().getId(), orderEntity.getUserCoupon().getId(), orderEntity.getTotalPrice(), orderEntity.getId()));
         }
 
         // 8. 결제
@@ -90,6 +91,8 @@ public class OrderFacade {
                 orderEntity.getPayment().getMethod(),
                 orderEntity.getId()
         ));
+
+        eventPublisher.publishEvent(DataPlatformSendEvent.orderComplete(orderEntity.getId(), user.getId(), orderEntity.getUuid(), orderEntity.getTotalPrice()));
         return OrderInfo.from(orderEntity);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,6 +1,5 @@
 package com.loopers.application.order;
 
-import com.loopers.application.payment.PaymentCommand;
 import com.loopers.domain.coupon.UserCouponDomainService;
 import com.loopers.domain.coupon.UserCouponEntity;
 import com.loopers.domain.coupon.UserCouponService;
@@ -73,11 +72,9 @@ public class OrderFacade {
             userCouponDomainService.useCoupon(userCoupon, calculatePrice);
         }
 
-        // 7. 결제 정보 확인
-        PaymentCommand.Payment paymentCommand = new PaymentCommand.Payment(request.payment().method(), request.totalPrice(), request.payment().cardId());
-
         // 7. 주문
-        OrderEntity orderEntity = orderService.order(user, itemList, calculatePrice, userCoupon, paymentCommand);
+        OrderEntity orderEntity = orderService.order(user, itemList, calculatePrice, userCoupon);
+        paymentService.addPaymentToOrder(orderEntity, request.payment().method(), request.payment().cardId());
 
         // 8. 결제
         Boolean result = paymentService.payment(user, orderEntity);

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderInfo.java
@@ -11,20 +11,12 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 public record OrderInfo(Long id, UserInfo userInfo, Long totalPrice, List<ProductInfo> items, ZonedDateTime createdAt,
-                        UserCouponInfo userCouponInfo, Boolean payResult) {
+                        UserCouponInfo userCouponInfo) {
     public static OrderInfo from(OrderEntity orderEntity) {
-        return new OrderInfo(orderEntity.getId(), UserInfo.from(orderEntity.getUser()), orderEntity.getTotalPrice(), orderEntity.getItems().stream().map(OrderItemEntity::getProduct).map(ProductInfo::from).toList(), orderEntity.getCreatedAt(), UserCouponInfo.from(orderEntity.getUserCoupon()), true);
+        return new OrderInfo(orderEntity.getId(), UserInfo.from(orderEntity.getUser()), orderEntity.getTotalPrice(), orderEntity.getItems().stream().map(OrderItemEntity::getProduct).map(ProductInfo::from).toList(), orderEntity.getCreatedAt(), UserCouponInfo.from(orderEntity.getUserCoupon()));
     }
 
     public static OrderInfo from(OrderEntity orderEntity, UserCouponEntity userCoupon) {
-        return new OrderInfo(orderEntity.getId(), UserInfo.from(orderEntity.getUser()), orderEntity.getTotalPrice(), orderEntity.getItems().stream().map(OrderItemEntity::getProduct).map(ProductInfo::from).toList(), orderEntity.getCreatedAt(), UserCouponInfo.from(userCoupon), true);
-    }
-
-    public static OrderInfo from(OrderEntity orderEntity, Boolean payResult) {
-        return new OrderInfo(orderEntity.getId(), UserInfo.from(orderEntity.getUser()), orderEntity.getTotalPrice(), orderEntity.getItems().stream().map(OrderItemEntity::getProduct).map(ProductInfo::from).toList(), orderEntity.getCreatedAt(), UserCouponInfo.from(orderEntity.getUserCoupon()), payResult);
-    }
-
-    public static OrderInfo from(OrderEntity orderEntity, UserCouponEntity userCoupon, Boolean payResult) {
-        return new OrderInfo(orderEntity.getId(), UserInfo.from(orderEntity.getUser()), orderEntity.getTotalPrice(), orderEntity.getItems().stream().map(OrderItemEntity::getProduct).map(ProductInfo::from).toList(), orderEntity.getCreatedAt(), UserCouponInfo.from(userCoupon), payResult);
+        return new OrderInfo(orderEntity.getId(), UserInfo.from(orderEntity.getUser()), orderEntity.getTotalPrice(), orderEntity.getItems().stream().map(OrderItemEntity::getProduct).map(ProductInfo::from).toList(), orderEntity.getCreatedAt(), UserCouponInfo.from(userCoupon));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -43,9 +43,9 @@ public class PaymentFacade {
         OrderEntity order = orderService.getOrderForPay(transactionKey, orderUUID);
 
         if (status.equals(PaymentStatus.SUCCESS)) {
-            eventPublisher.publishEvent(new PaymentSuccessEvent(order.getPayment().getId()));
+            eventPublisher.publishEvent(new PaymentSuccessEvent(order.getPayment().getId(), order.getId(), order.getUser().getId(), orderUUID, order.getTotalPrice(), order.getPayment().getMethod().name()));
         } else {
-            eventPublisher.publishEvent(new PaymentFailEvent(order.getPayment().getId(), reason));
+            eventPublisher.publishEvent(new PaymentFailEvent(order.getPayment().getId(), order.getId(), order.getUser().getId(), reason));
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -5,10 +5,13 @@ import com.loopers.domain.order.OrderService;
 import com.loopers.domain.payment.PaymentMethod;
 import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.interfaces.listener.payment.PaymentFailEvent;
+import com.loopers.interfaces.listener.payment.PaymentSuccessEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,7 @@ import java.util.List;
 public class PaymentFacade {
     private final OrderService orderService;
     private final PaymentService paymentService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void paymentCallback(String transactionKey, String orderUUID, PaymentStatus status, String reason) {
@@ -39,10 +43,9 @@ public class PaymentFacade {
         OrderEntity order = orderService.getOrderForPay(transactionKey, orderUUID);
 
         if (status.equals(PaymentStatus.SUCCESS)) {
-            paymentService.pay(order);
+            eventPublisher.publishEvent(new PaymentSuccessEvent(order.getPayment().getId()));
         } else {
-            paymentService.fail(order, reason);
-            orderService.rollbackOrder(order);
+            eventPublisher.publishEvent(new PaymentFailEvent(order.getPayment().getId(), reason));
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponDomainService.java
@@ -13,6 +13,8 @@ import java.time.ZonedDateTime;
 @RequiredArgsConstructor
 public class UserCouponDomainService {
 
+    private final UserCouponRepository userCouponRepository;
+
     public void validateUseCoupon(UserEntity user, UserCouponEntity userCoupon, Long totalPrice) {
         // 0. 파라미터 확인
         if (user == null) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponEntity.java
@@ -63,6 +63,9 @@ public class UserCouponEntity extends BaseEntity {
     }
 
     public void use(Long beforePrice) {
+        if (this.usedAt != null) {
+            throw new CoreException(GlobalErrorType.BAD_REQUEST, "이미 사용된 쿠폰입니다.");
+        }
         this.usedAt = ZonedDateTime.now();
         this.beforePrice = beforePrice;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponEntity.java
@@ -66,4 +66,9 @@ public class UserCouponEntity extends BaseEntity {
         this.usedAt = ZonedDateTime.now();
         this.beforePrice = beforePrice;
     }
+
+    public void rollback() {
+        this.usedAt = null;
+        this.beforePrice = null;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponService.java
@@ -1,8 +1,10 @@
 package com.loopers.domain.coupon;
 
+import com.loopers.interfaces.listener.payment.PaymentFailEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,7 @@ import java.util.Optional;
 public class UserCouponService {
 
     private final UserCouponRepository userCouponRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Optional<UserCouponEntity> getCouponInfoWithLock(Long couponId) {
@@ -34,5 +37,15 @@ public class UserCouponService {
             throw new CoreException(GlobalErrorType.NOT_FOUND, "쿠폰이 이미 삭제되었습니다.");
         }
         return optionalUserCouponEntity;
+    }
+
+    @Transactional
+    public void useCoupon(Long paymentId, Long couponId, Long calculatePrice) {
+        UserCouponEntity userCoupon = userCouponRepository.findById(couponId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+        try {
+            userCoupon.use(calculatePrice);
+        } catch (CoreException e) {
+            eventPublisher.publishEvent(new PaymentFailEvent(paymentId, "이미 사용된 쿠폰입니다."));
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponService.java
@@ -40,12 +40,12 @@ public class UserCouponService {
     }
 
     @Transactional
-    public void useCoupon(Long paymentId, Long couponId, Long calculatePrice) {
+    public void useCoupon(Long orderId, Long paymentId, Long couponId, Long calculatePrice) {
         UserCouponEntity userCoupon = userCouponRepository.findById(couponId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
         try {
             userCoupon.use(calculatePrice);
         } catch (CoreException e) {
-            eventPublisher.publishEvent(new PaymentFailEvent(paymentId, "이미 사용된 쿠폰입니다."));
+            eventPublisher.publishEvent(new PaymentFailEvent(paymentId, orderId, userCoupon.getUser().getId(), "이미 사용된 쿠폰입니다."));
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,11 +1,15 @@
 package com.loopers.domain.like;
 
 import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.UserEntity;
+import com.loopers.interfaces.listener.like.DisLikeEvent;
+import com.loopers.interfaces.listener.like.LikeEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,9 +22,10 @@ import java.util.Optional;
 public class LikeService {
 
     private final LikeRepository likeRepository;
+    private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional(propagation = Propagation.REQUIRED)
-    @CacheEvict(value = "product", key = "'product:' + #productEntity.id")
+    @Transactional
     public LikeEntity like(UserEntity userEntity, ProductEntity productEntity) {
         if (userEntity == null) {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 정보가 없습니다.");
@@ -32,15 +37,21 @@ public class LikeService {
         LikeEntity likeEntity = optionalLikeEntity.orElse(new LikeEntity(userEntity, productEntity, false));
 
         if (!likeEntity.getIsLike()) {
-            productEntity.increaseLikeCount();
+            eventPublisher.publishEvent(new LikeEvent(productEntity.getId(), userEntity.getId()));
         }
-
         likeEntity.like();
         return likeRepository.save(likeEntity);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
-    @CacheEvict(value = "product", key = "'product:' + #productEntity.id")
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @CacheEvict(value = "product", key = "'product:' + #productId")
+    public void increaseProductLikeCount(Long productId) {
+        ProductEntity productEntity = productRepository.getProductInfoWithLock(productId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "상품 정보가 없습니다."));
+        productEntity.increaseLikeCount();
+    }
+
+    @Transactional
     public LikeEntity dislike(UserEntity userEntity, ProductEntity productEntity) {
         if (userEntity == null) {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 정보가 없습니다.");
@@ -54,12 +65,20 @@ public class LikeService {
         } else {
             LikeEntity likeEntity = optionalLikeEntity.get();
             if (likeEntity.getIsLike()) {
-                productEntity.decreaseLikeCount();
+                eventPublisher.publishEvent(new DisLikeEvent(productEntity.getId(), userEntity.getId()));
             }
             likeEntity.dislike();
             return likeRepository.save(likeEntity);
         }
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @CacheEvict(value = "product", key = "'product:' + #productId")
+    public void decreaseProductLikeCount(Long productId) {
+        ProductEntity productEntity = productRepository.getProductInfoWithLock(productId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "상품 정보가 없습니다."));
+        productEntity.decreaseLikeCount();
+    }
+
 
     @Transactional(readOnly = true)
     public List<LikeEntity> getUserLikeList(UserEntity userEntity) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
@@ -9,10 +9,10 @@ import com.loopers.support.error.GlobalErrorType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -46,13 +46,13 @@ public class OrderEntity extends BaseEntity {
     private PaymentEntity payment;
 
     @Schema(name = "주문 UUID")
-    @UuidGenerator
     @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(36)")
     private String uuid;
 
     protected OrderEntity() {
 
     }
+
 
     public OrderEntity(UserEntity user, Long totalPrice, UserCouponEntity userCoupon) {
         if (user == null) {
@@ -72,6 +72,13 @@ public class OrderEntity extends BaseEntity {
         this.status = OrderStatus.PENDING;
     }
 
+    @PrePersist
+    private void generateUuid() {
+        if (this.uuid == null) {
+            this.uuid = UUID.randomUUID().toString();
+        }
+    }
+
     public void addPayment(PaymentEntity paymentEntity) {
         if (paymentEntity == null) {
             throw new CoreException(GlobalErrorType.BAD_REQUEST, "결제 방식이 null이 될 수 없습니다.");
@@ -87,11 +94,6 @@ public class OrderEntity extends BaseEntity {
         this.items.add(orderItem);
         orderItem.updateOrder(this);
     }
-
-    public void updateTransactionKey(String transactionKey) {
-        this.payment.updateTransactionKey(transactionKey);
-    }
-
 
     public void payFailed(String reason) {
         this.status = OrderStatus.FAILED;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -26,7 +26,7 @@ public class OrderService {
     private final OrderDomainService orderDomainService;
 
     @Transactional
-    public OrderEntity order(UserEntity user, List<OrderCommand.OrderProduct> itemList, Long totalPrice, UserCouponEntity userCoupon) {
+    public OrderEntity createOrder(UserEntity user, List<OrderCommand.OrderProduct> itemList, Long totalPrice, UserCouponEntity userCoupon) {
         // 0. 파라미터 값 체크
         if (user == null) {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 정보가 없습니다.");
@@ -42,8 +42,7 @@ public class OrderService {
 
         // 2. 주문 생성
         OrderEntity orderEntity = orderDomainService.createOrder(user, itemList, totalPrice, userCoupon);
-
-        return orderRepository.save(orderEntity);
+        return orderEntity;
     }
 
 
@@ -116,5 +115,10 @@ public class OrderService {
     @Transactional
     public List<OrderEntity> getPendingOrderList(ZonedDateTime startAt, ZonedDateTime endAt) {
         return orderRepository.findOrdersByStatusAndCreatedAtBetweenWithCardPay(OrderStatus.PENDING, startAt, endAt);
+    }
+
+    @Transactional
+    public OrderEntity saveOrder(OrderEntity orderEntity) {
+        return orderRepository.save(orderEntity);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,9 +1,7 @@
 package com.loopers.domain.order;
 
 import com.loopers.application.order.OrderCommand;
-import com.loopers.application.payment.PaymentCommand;
 import com.loopers.domain.coupon.UserCouponEntity;
-import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.user.UserEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
@@ -26,10 +24,9 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final OrderDomainService orderDomainService;
-    private final PaymentService paymentService;
 
     @Transactional
-    public OrderEntity order(UserEntity user, List<OrderCommand.OrderProduct> itemList, Long totalPrice, UserCouponEntity userCoupon, PaymentCommand.Payment paymentCommand) {
+    public OrderEntity order(UserEntity user, List<OrderCommand.OrderProduct> itemList, Long totalPrice, UserCouponEntity userCoupon) {
         // 0. 파라미터 값 체크
         if (user == null) {
             throw new CoreException(GlobalErrorType.UNAUTHORIZED, "사용자 정보가 없습니다.");
@@ -45,7 +42,6 @@ public class OrderService {
 
         // 2. 주문 생성
         OrderEntity orderEntity = orderDomainService.createOrder(user, itemList, totalPrice, userCoupon);
-        paymentService.addPaymentToOrder(orderEntity, paymentCommand);
 
         return orderRepository.save(orderEntity);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -108,6 +108,9 @@ public class OrderService {
         for (OrderItemEntity orderItem : order.getItems()) {
             orderItem.getProduct().increaseQuantity(orderItem.getQuantity());
         }
+        if (order.getUserCoupon() != null) {
+            order.getUserCoupon().rollback();
+        }
     }
 
     @Transactional

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,5 +1,9 @@
 package com.loopers.domain.payment;
 
+import java.util.Optional;
+
 public interface PaymentRepository {
     PaymentEntity save(PaymentEntity paymentEntity);
+
+    Optional<PaymentEntity> findById(Long paymentId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -1,6 +1,5 @@
 package com.loopers.domain.payment;
 
-import com.loopers.application.payment.PaymentCommand;
 import com.loopers.application.payment.PaymentGateway;
 import com.loopers.domain.order.OrderEntity;
 import com.loopers.domain.order.OrderRepository;
@@ -34,12 +33,13 @@ public class PaymentService {
         else return cardRepository.findById(cardId);
     }
 
-    public void addPaymentToOrder(OrderEntity order, PaymentCommand.Payment paymentCommand) {
-        CardEntity card = getCardInfo(paymentCommand.cardId()).orElse(null);
+    @Transactional
+    public void addPaymentToOrder(OrderEntity order, String method, Long cardId) {
+        CardEntity card = getCardInfo(cardId).orElse(null);
         if (card != null && !card.getUser().getId().equals(order.getUser().getId())) {
             throw new CoreException(GlobalErrorType.FORBIDDEN, "사용자 카드가 아닙니다.");
         }
-        PaymentEntity paymentEntity = new PaymentEntity(order, PaymentMethod.from(paymentCommand.method()), card, PaymentStatus.PENDING);
+        PaymentEntity paymentEntity = new PaymentEntity(order, PaymentMethod.from(method), card, PaymentStatus.PENDING);
         order.addPayment(paymentEntity);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -2,8 +2,7 @@ package com.loopers.domain.payment;
 
 import com.loopers.application.payment.PaymentGateway;
 import com.loopers.domain.order.OrderEntity;
-import com.loopers.domain.order.OrderRepository;
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.order.OrderService;
 import com.loopers.domain.user.UserService;
 import com.loopers.infrastructure.payment.PgPaymentInfraV1Dto;
 import com.loopers.interfaces.api.payment.PaymentV1Dto;
@@ -23,9 +22,11 @@ public class PaymentService {
 
     private final UserService userService;
     private final CardRepository cardRepository;
+    private final PaymentRepository paymentRepository;
     private final PgPayService pgPayService;
-    private final OrderRepository orderRepository;
     private final PaymentGateway paymentGateway;
+    private final OrderService orderService;
+
 
     @Transactional(readOnly = true)
     public Optional<CardEntity> getCardInfo(Long cardId) {
@@ -44,15 +45,23 @@ public class PaymentService {
     }
 
     @Transactional
-    public Boolean payment(UserEntity user, OrderEntity order) {
-        switch (order.getPayment().getMethod()) {
+    public Boolean payment(Long userId, Long paymentId, String orderUuid, Long orderId) {
+        PaymentEntity paymentEntity = paymentRepository.findById(paymentId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "결제 정보가 없습니다."));
+        switch (paymentEntity.getMethod()) {
             case POINT -> {
-                userService.usePoint(user, order.getTotalPrice());
-                order.getPayment().updateStatus(PaymentStatus.SUCCESS);
+                userService.usePoint(userId, paymentEntity.getOrder().getTotalPrice());
+                paymentEntity.updateStatus(PaymentStatus.SUCCESS);
                 return true;
             }
             case CARD -> {
-                return pgPayService.pay(order);
+                PgPaymentInfraV1Dto.PaymentResponse response = pgPayService.pay(userId, orderUuid, paymentEntity.getCard().getUser().getName(), paymentEntity.getCard().getNumber(), paymentEntity.getOrder().getTotalPrice());
+                if (response.isSuccess()) {
+                    paymentEntity.updateTransactionKey(response.transactionKey());
+                } else {
+                    paymentEntity.getOrder().payFailed(response.reason());
+                }
+                return response.isSuccess();
+
             }
         }
         return true;
@@ -75,7 +84,6 @@ public class PaymentService {
             if (!result.meta().result().equals("SUCCESS")) {
                 return;
             }
-
             if (!result.data().orderId().equals(order.getUuid())) {
                 log.warn("트랜젝션 번호와 주문 Uuid가 일치하지 않습니다. [orderId={}, orderUUID={}, transactionKey={}]", order.getId(), order.getUuid(), order.getPayment().getTransactionKey());
             } else if (result.data().status().equals(PaymentV1Dto.TransactionStatusResponse.SUCCESS)) {
@@ -86,5 +94,12 @@ public class PaymentService {
         } catch (CoreException e) {
             log.info("에러가 발생했습니다. 메세지: {}", e.getMessage());
         }
+    }
+
+    @Transactional
+    public void paymentFail(Long paymentId, String reason) {
+        PaymentEntity paymentEntity = paymentRepository.findById(paymentId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "결제 정보가 없습니다."));
+        orderService.rollbackOrder(paymentEntity.getOrder());
+        paymentEntity.getOrder().payFailed(reason);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -6,10 +6,13 @@ import com.loopers.domain.order.OrderService;
 import com.loopers.domain.user.UserService;
 import com.loopers.infrastructure.payment.PgPaymentInfraV1Dto;
 import com.loopers.interfaces.api.payment.PaymentV1Dto;
+import com.loopers.interfaces.listener.payment.PaymentFailEvent;
+import com.loopers.interfaces.listener.payment.PaymentSuccessEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,7 @@ public class PaymentService {
     private final PgPayService pgPayService;
     private final PaymentGateway paymentGateway;
     private final OrderService orderService;
+    private final ApplicationEventPublisher eventPublisher;
 
 
     @Transactional(readOnly = true)
@@ -50,7 +54,7 @@ public class PaymentService {
         switch (paymentEntity.getMethod()) {
             case POINT -> {
                 userService.usePoint(userId, paymentEntity.getOrder().getTotalPrice());
-                paymentEntity.updateStatus(PaymentStatus.SUCCESS);
+                eventPublisher.publishEvent(new PaymentSuccessEvent(paymentId));
                 return true;
             }
             case CARD -> {
@@ -58,23 +62,13 @@ public class PaymentService {
                 if (response.isSuccess()) {
                     paymentEntity.updateTransactionKey(response.transactionKey());
                 } else {
-                    paymentEntity.getOrder().payFailed(response.reason());
+                    eventPublisher.publishEvent(new PaymentFailEvent(paymentId, response.reason()));
                 }
                 return response.isSuccess();
 
             }
         }
         return true;
-    }
-
-    @Transactional
-    public void pay(OrderEntity order) {
-        order.paySuccess();
-    }
-
-    @Transactional
-    public void fail(OrderEntity order, String reason) {
-        order.payFailed(reason);
     }
 
     @Transactional
@@ -87,9 +81,9 @@ public class PaymentService {
             if (!result.data().orderId().equals(order.getUuid())) {
                 log.warn("트랜젝션 번호와 주문 Uuid가 일치하지 않습니다. [orderId={}, orderUUID={}, transactionKey={}]", order.getId(), order.getUuid(), order.getPayment().getTransactionKey());
             } else if (result.data().status().equals(PaymentV1Dto.TransactionStatusResponse.SUCCESS)) {
-                pay(order);
+                eventPublisher.publishEvent(new PaymentSuccessEvent(order.getPayment().getId()));
             } else {
-                fail(order, result.data().reason());
+                eventPublisher.publishEvent(new PaymentFailEvent(order.getPayment().getId(), result.data().reason()));
             }
         } catch (CoreException e) {
             log.info("에러가 발생했습니다. 메세지: {}", e.getMessage());
@@ -101,5 +95,11 @@ public class PaymentService {
         PaymentEntity paymentEntity = paymentRepository.findById(paymentId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "결제 정보가 없습니다."));
         orderService.rollbackOrder(paymentEntity.getOrder());
         paymentEntity.getOrder().payFailed(reason);
+    }
+
+    @Transactional
+    public void paymentSuccess(Long paymentId) {
+        PaymentEntity paymentEntity = paymentRepository.findById(paymentId).orElseThrow(() -> new CoreException(GlobalErrorType.NOT_FOUND, "결제 정보가 없습니다."));
+        paymentEntity.getOrder().paySuccess();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -54,7 +54,7 @@ public class PaymentService {
         switch (paymentEntity.getMethod()) {
             case POINT -> {
                 userService.usePoint(userId, paymentEntity.getOrder().getTotalPrice());
-                eventPublisher.publishEvent(new PaymentSuccessEvent(paymentId));
+                eventPublisher.publishEvent(new PaymentSuccessEvent(paymentId, orderId, userId, orderUuid, paymentEntity.getOrder().getTotalPrice(), paymentEntity.getMethod().name()));
                 return true;
             }
             case CARD -> {
@@ -62,7 +62,7 @@ public class PaymentService {
                 if (response.isSuccess()) {
                     paymentEntity.updateTransactionKey(response.transactionKey());
                 } else {
-                    eventPublisher.publishEvent(new PaymentFailEvent(paymentId, response.reason()));
+                    eventPublisher.publishEvent(new PaymentFailEvent(paymentId, orderId, userId, response.reason()));
                 }
                 return response.isSuccess();
 
@@ -81,9 +81,9 @@ public class PaymentService {
             if (!result.data().orderId().equals(order.getUuid())) {
                 log.warn("트랜젝션 번호와 주문 Uuid가 일치하지 않습니다. [orderId={}, orderUUID={}, transactionKey={}]", order.getId(), order.getUuid(), order.getPayment().getTransactionKey());
             } else if (result.data().status().equals(PaymentV1Dto.TransactionStatusResponse.SUCCESS)) {
-                eventPublisher.publishEvent(new PaymentSuccessEvent(order.getPayment().getId()));
+                eventPublisher.publishEvent(new PaymentSuccessEvent(order.getPayment().getId(), order.getId(), order.getUser().getId(), order.getUuid(), order.getTotalPrice(), order.getPayment().getMethod().name()));
             } else {
-                eventPublisher.publishEvent(new PaymentFailEvent(order.getPayment().getId(), result.data().reason()));
+                eventPublisher.publishEvent(new PaymentFailEvent(order.getPayment().getId(), order.getId(), order.getUser().getId(), result.data().reason()));
             }
         } catch (CoreException e) {
             log.info("에러가 발생했습니다. 메세지: {}", e.getMessage());

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PgPayService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PgPayService.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.payment;
 
 import com.loopers.application.payment.PaymentGateway;
-import com.loopers.domain.order.OrderEntity;
 import com.loopers.infrastructure.payment.PgPaymentInfraV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
@@ -19,20 +18,11 @@ public class PgPayService {
     private final PaymentGateway paymentGateway;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Boolean pay(OrderEntity order) {
-        if (order == null) {
+    public PgPaymentInfraV1Dto.PaymentResponse pay(Long userId, String orderUuid, String cardName, String cardNumber, Long totalPrice) {
+        if (orderUuid == null) {
             throw new CoreException(GlobalErrorType.BAD_REQUEST, "카드 결제 시, 주문 정보는 필수입니다.");
         }
-        if (!order.getPayment().getMethod().equals(PaymentMethod.CARD)) {
-            throw new CoreException(GlobalErrorType.BAD_REQUEST, "카드 결제를 하려면 주문 결제 방식이 카드여야 합니다.");
-        }
-
-        PgPaymentInfraV1Dto.PaymentResponse response = paymentGateway.requestPayment(order.getUser().getId(), order.getUuid(), order.getPayment().getCard().getType().name(), order.getPayment().getCard().getNumber(), order.getTotalPrice());
-        if (response.isSuccess()) {
-            order.updateTransactionKey(response.transactionKey());
-        } else {
-            order.payFailed(response.reason());
-        }
-        return response.isSuccess();
+        PgPaymentInfraV1Dto.PaymentResponse response = paymentGateway.requestPayment(userId, orderUuid, cardName, cardNumber, totalPrice);
+        return response;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository {
 
     Optional<UserEntity> findByLoginIdWithLock(String userId);
 
+    Optional<UserEntity> findByIdWithLock(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -53,9 +53,7 @@ public class UserService {
     @Transactional
     public void usePoint(Long userId, Long point) {
         UserEntity userEntity = userRepository.findByIdWithLock(userId).orElseThrow(() -> new CoreException(UserErrorType.USER_NOT_EXISTS));
-        System.out.println("before =====> " + userEntity.getId() + " " + userEntity.getPoint());
         userEntity.usePoint(point);
-        System.out.println("after =====> " + userEntity.getId() + " " + userEntity.getPoint());
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -50,4 +50,12 @@ public class UserService {
         userEntity.usePoint(point);
     }
 
+    @Transactional
+    public void usePoint(Long userId, Long point) {
+        UserEntity userEntity = userRepository.findByIdWithLock(userId).orElseThrow(() -> new CoreException(UserErrorType.USER_NOT_EXISTS));
+        System.out.println("before =====> " + userEntity.getId() + " " + userEntity.getPoint());
+        userEntity.usePoint(point);
+        System.out.println("after =====> " + userEntity.getId() + " " + userEntity.getPoint());
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/DataPlatformClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/DataPlatformClient.java
@@ -1,0 +1,28 @@
+package com.loopers.infrastructure.dataplatform;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DataPlatformClient {
+    public void sendOrderData(OrderDataPlatformV1Dto.OrderSuccess orderInfo) {
+        log.info("데이터 플랫폼으로 주문 데이터 전송: {}", orderInfo);
+
+        // 시뮬레이션을 위한 지연
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void sendPaymentData(PaymentDataPlatformV1Dto.PaymentSuccess paymentInfo) {
+        log.info("데이터 플랫폼으로 결제 데이터 전송: {}", paymentInfo);
+    }
+
+    public void sendPaymentFailureData(PaymentDataPlatformV1Dto.PaymentFailure failureData) {
+        log.info("데이터 플랫폼으로 결제 실패 데이터 전송: {}", failureData);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/OrderDataPlatformV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/OrderDataPlatformV1Dto.java
@@ -1,0 +1,16 @@
+package com.loopers.infrastructure.dataplatform;
+
+import com.loopers.interfaces.listener.dataplatform.DataPlatformSendEvent;
+
+public class OrderDataPlatformV1Dto {
+    public record OrderSuccess(
+            Long orderId,
+            Long userId,
+            Long price
+    ) {
+
+        public static OrderSuccess from(DataPlatformSendEvent event) {
+            return new OrderSuccess(event.orderId(), event.userId(), event.totalPrice());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/PaymentDataPlatformV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/PaymentDataPlatformV1Dto.java
@@ -1,0 +1,31 @@
+package com.loopers.infrastructure.dataplatform;
+
+import com.loopers.interfaces.listener.dataplatform.DataPlatformSendEvent;
+
+public class PaymentDataPlatformV1Dto {
+    public record PaymentSuccess(
+            Long paymentId,
+            Long orderId,
+            Long userId,
+            String method,
+            Long price
+    ) {
+
+        public static PaymentSuccess from(DataPlatformSendEvent event) {
+            return new PaymentSuccess(event.paymentId(), event.orderId(), event.userId(), event.paymentMethod(), event.totalPrice());
+        }
+    }
+
+    public record PaymentFailure(
+            Long paymentId,
+            Long orderId,
+            Long userId,
+            String method,
+            Long price,
+            String reason
+    ) {
+        public static PaymentFailure from(DataPlatformSendEvent event) {
+            return new PaymentFailure(event.paymentId(), event.orderId(), event.userId(), event.paymentMethod(), event.totalPrice(), event.failReason());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayImpl.java
@@ -31,7 +31,7 @@ public class PaymentGatewayImpl implements PaymentGateway {
         // 유효성 검증
         validatePaymentRequest(userId, orderUUID, cardType, cardNo, amount);
 
-        String url = "http://localhost:8082/api/v1/payments";
+        String url = "http://localhost:8083/api/v1/payments";
         String callbackUrl = "http://localhost:8080/api/v1/payments/callback";
 
         HttpHeaders headers = new HttpHeaders();

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,9 +1,15 @@
 package com.loopers.infrastructure.payment;
 
 import com.loopers.domain.payment.PaymentEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 
 public interface PaymentJpaRepository extends JpaRepository<PaymentEntity, Long> {
     PaymentEntity save(PaymentEntity paymentEntity);
+
+    @EntityGraph(attributePaths = {"order", "card"})
+    Optional<PaymentEntity> findById(Long paymentId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.loopers.domain.payment.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Component
 public class PaymentRepositoryImpl implements PaymentRepository {
@@ -13,5 +15,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public PaymentEntity save(PaymentEntity paymentEntity) {
         return paymentJpaRepository.save(paymentEntity);
+    }
+
+    @Override
+    public Optional<PaymentEntity> findById(Long paymentId) {
+        return paymentJpaRepository.findById(paymentId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -18,4 +18,8 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u FROM UserEntity u WHERE u.loginId = :loginId")
     Optional<UserEntity> findByLoginIdWithLock(@Param("loginId") String loginId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM UserEntity u WHERE u.id = :id")
+    Optional<UserEntity> findByIdWithLock(@Param("id") Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -32,4 +32,9 @@ public class UserRepositoryImpl implements UserRepository {
     public Optional<UserEntity> findByLoginIdWithLock(String loginId) {
         return userJpaRepository.findByLoginIdWithLock(loginId);
     }
+
+    @Override
+    public Optional<UserEntity> findByIdWithLock(Long userId) {
+        return userJpaRepository.findByIdWithLock(userId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -3,8 +3,6 @@ package com.loopers.interfaces.api.order;
 import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.OrderInfo;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.GlobalErrorType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,11 +23,11 @@ public class OrderV1Controller implements OrderV1ApiSpec {
             @RequestHeader("X-USER-ID") String userId,
             @RequestBody OrderV1Dto.OrderRequest orderRequest) {
         OrderInfo orderInfo = orderFacade.order(userId, orderRequest);
-        if (orderInfo.payResult()) {
-            return ApiResponse.success(OrderV1Dto.OrderResponse.from(orderInfo));
-        } else {
-            throw new CoreException(GlobalErrorType.INTERNAL_ERROR, "결제 PG 연결에 실패하였습니다.");
-        }
+//        if (orderInfo.payResult()) {
+        return ApiResponse.success(OrderV1Dto.OrderResponse.from(orderInfo));
+//        } else {
+//            throw new CoreException(GlobalErrorType.INTERNAL_ERROR, "결제 PG 연결에 실패하였습니다.");
+//        }
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/CouponUseEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/CouponUseEventListener.java
@@ -17,7 +17,7 @@ public class CouponUseEventListener {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleUseCoupon(UserCouponUseEvent event) {
         log.info("handleUseCoupon 발생");
-        userCouponService.useCoupon(event.getPaymentId(), event.getUserCouponId(), event.getUseBeforePrice());
+        userCouponService.useCoupon(event.getOrderId(), event.getPaymentId(), event.getUserCouponId(), event.getUseBeforePrice());
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/CouponUseEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/CouponUseEventListener.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.listener.coupon;
+
+import com.loopers.domain.coupon.UserCouponService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CouponUseEventListener {
+
+    private final UserCouponService userCouponService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleUseCoupon(UserCouponUseEvent event) {
+        log.info("handleUseCoupon 발생");
+        userCouponService.useCoupon(event.getPaymentId(), event.getUserCouponId(), event.getUseBeforePrice());
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/UserCouponUseEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/UserCouponUseEvent.java
@@ -9,4 +9,5 @@ public class UserCouponUseEvent {
     private final Long userCouponId;
     private final Long useBeforePrice;
     private final Long paymentId;
+    private final Long orderId;
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/UserCouponUseEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/coupon/UserCouponUseEvent.java
@@ -1,0 +1,12 @@
+package com.loopers.interfaces.listener.coupon;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserCouponUseEvent {
+    private final Long userCouponId;
+    private final Long useBeforePrice;
+    private final Long paymentId;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/dataplatform/DataPlatformEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/dataplatform/DataPlatformEventListener.java
@@ -1,0 +1,44 @@
+package com.loopers.interfaces.listener.dataplatform;
+
+import com.loopers.infrastructure.dataplatform.DataPlatformClient;
+import com.loopers.infrastructure.dataplatform.OrderDataPlatformV1Dto;
+import com.loopers.infrastructure.dataplatform.PaymentDataPlatformV1Dto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DataPlatformEventListener {
+
+    private final DataPlatformClient dataPlatformClient;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleDataPlatformSend(DataPlatformSendEvent event) {
+        try {
+            switch (event.eventType()) {
+                case "PAYMENT_SUCCESS" -> {
+                    PaymentDataPlatformV1Dto.PaymentSuccess data = PaymentDataPlatformV1Dto.PaymentSuccess.from(event);
+                    dataPlatformClient.sendPaymentData(data);
+                }
+                case "PAYMENT_FAIL" -> {
+                    PaymentDataPlatformV1Dto.PaymentFailure data = PaymentDataPlatformV1Dto.PaymentFailure.from(event);
+                    dataPlatformClient.sendPaymentFailureData(data);
+                }
+                case "ORDER_COMPLETE" -> {
+                    OrderDataPlatformV1Dto.OrderSuccess data = OrderDataPlatformV1Dto.OrderSuccess.from(event);
+                    dataPlatformClient.sendOrderData(data);
+                }
+            }
+            log.info("데이터 플랫폼 전송 완료: {}", event.eventType());
+        } catch (Exception e) {
+            log.error("데이터 플랫폼 전송 실패: {}, error={}", event.eventType(), e.getMessage());
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/dataplatform/DataPlatformSendEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/dataplatform/DataPlatformSendEvent.java
@@ -1,0 +1,27 @@
+package com.loopers.interfaces.listener.dataplatform;
+
+import java.time.LocalDateTime;
+
+public record DataPlatformSendEvent(
+        String eventType,      // "PAYMENT_SUCCESS", "PAYMENT_FAIL", "ORDER_COMPLETE"
+        Long orderId,
+        Long paymentId,
+        Long userId,
+        String orderUuid,
+        Long totalPrice,
+        String paymentMethod,
+        String failReason,     // 실패시에만
+        LocalDateTime dateTime
+) {
+    public static DataPlatformSendEvent paymentSuccess(Long paymentId, Long orderId, Long userId, String orderUuid, Long totalPrice, String paymentMethod) {
+        return new DataPlatformSendEvent("PAYMENT_SUCCESS", orderId, paymentId, userId, orderUuid, totalPrice, paymentMethod, null, LocalDateTime.now());
+    }
+
+    public static DataPlatformSendEvent paymentFail(Long paymentId, Long orderId, String failReason) {
+        return new DataPlatformSendEvent("PAYMENT_FAIL", orderId, paymentId, null, null, null, null, failReason, LocalDateTime.now());
+    }
+
+    public static DataPlatformSendEvent orderComplete(Long orderId, Long userId, String orderUuid, Long totalPrice) {
+        return new DataPlatformSendEvent("ORDER_COMPLETE", orderId, null, userId, orderUuid, totalPrice, null, null, LocalDateTime.now());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/like/DisLikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/like/DisLikeEvent.java
@@ -1,0 +1,5 @@
+package com.loopers.interfaces.listener.like;
+
+public record DisLikeEvent(Long productId, Long userId) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/like/LikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/like/LikeEvent.java
@@ -1,0 +1,5 @@
+package com.loopers.interfaces.listener.like;
+
+public record LikeEvent(Long productId, Long userId) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/like/LikeEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/like/LikeEventListener.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.listener.like;
+
+import com.loopers.domain.like.LikeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LikeEventListener {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final LikeService likeService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLike(LikeEvent event) {
+        log.info("좋아요 이벤트 처리: productId={}", event.productId());
+        likeService.increaseProductLikeCount(event.productId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDisLike(DisLikeEvent event) {
+        log.info("좋아요 취소 이벤트 처리: productId={}", event.productId());
+        likeService.decreaseProductLikeCount(event.productId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderCompletedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderCompletedEvent.java
@@ -1,0 +1,12 @@
+package com.loopers.interfaces.listener.order;
+
+import java.time.LocalDateTime;
+
+public record OrderCompletedEvent(
+        Long orderId,
+        Long userId,
+        String orderUuid,
+        Long totalPrice,
+        LocalDateTime completedAt
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderEventListener.java
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.listener.order;
+
+import com.loopers.interfaces.listener.dataplatform.DataPlatformSendEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventListener {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCompleted(OrderCompletedEvent event) {
+        log.info("주문 완료 이벤트 처리: orderId={}", event.orderId());
+
+        // 데이터 플랫폼 전송 이벤트 발행
+        eventPublisher.publishEvent(DataPlatformSendEvent.orderComplete(
+                event.orderId(),
+                event.userId(),
+                event.orderUuid(),
+                event.totalPrice()
+        ));
+
+        // 사용자 행동 로깅 이벤트도 발행 가능
+//        eventPublisher.publishEvent(new UserActionEvent("ORDER_COMPLETE", event.userId(), event.orderId()));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentCreateEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentCreateEvent.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.listener.payment;
+
+import com.loopers.domain.payment.PaymentMethod;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PaymentCreateEvent {
+    private Long userId;
+    private Long paymentId;
+    private String orderUuid;
+    private PaymentMethod method;
+    private Long orderId;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentEventListener.java
@@ -1,8 +1,10 @@
 package com.loopers.interfaces.listener.payment;
 
 import com.loopers.domain.payment.PaymentService;
+import com.loopers.interfaces.listener.dataplatform.DataPlatformSendEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PaymentEventListener {
 
     private final PaymentService paymentService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -28,13 +31,22 @@ public class PaymentEventListener {
     public void handlePaymentFail(PaymentFailEvent event) {
         log.info("payment fail event 발생: {}", event.getPaymentId());
         paymentService.paymentFail(event.getPaymentId(), event.getReason());
+        eventPublisher.publishEvent(DataPlatformSendEvent.paymentFail(event.getPaymentId(), event.getOrderId(), event.getReason()));
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handlePaymentSuccess(PaymentFailEvent event) {
+    public void handlePaymentSuccess(PaymentSuccessEvent event) {
         log.info("payment success event 발생: {}", event.getPaymentId());
         paymentService.paymentSuccess(event.getPaymentId());
+        eventPublisher.publishEvent(DataPlatformSendEvent.paymentSuccess(
+                event.getPaymentId(),
+                event.getOrderId(),
+                event.getUserId(),
+                event.getOrderUuid(),
+                event.getTotalPrice(),
+                event.getPaymentMethod()
+        ));
     }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentEventListener.java
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.listener.payment;
+
+import com.loopers.domain.payment.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventListener {
+
+    private final PaymentService paymentService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handlePayment(PaymentCreateEvent event) {
+        log.info("payment create event 발생: {}, {}, {}", event.getUserId(), event.getPaymentId(), event.getOrderUuid());
+        paymentService.payment(event.getUserId(), event.getPaymentId(), event.getOrderUuid(), event.getOrderId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handlePaymentFail(PaymentFailEvent event) {
+        log.info("payment fail event 발생: {}", event.getPaymentId());
+        paymentService.paymentFail(event.getPaymentId(), event.getReason());
+    }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentEventListener.java
@@ -30,5 +30,12 @@ public class PaymentEventListener {
         paymentService.paymentFail(event.getPaymentId(), event.getReason());
     }
 
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handlePaymentSuccess(PaymentFailEvent event) {
+        log.info("payment success event 발생: {}", event.getPaymentId());
+        paymentService.paymentSuccess(event.getPaymentId());
+    }
+
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentFailEvent.java
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.listener.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PaymentFailEvent {
+    private Long paymentId;
+    private String reason;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentFailEvent.java
@@ -7,5 +7,7 @@ import lombok.Getter;
 @Getter
 public class PaymentFailEvent {
     private Long paymentId;
+    private Long orderId;
+    private Long userId;
     private String reason;
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentSuccessEvent.java
@@ -1,0 +1,10 @@
+package com.loopers.interfaces.listener.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PaymentSuccessEvent {
+    private Long paymentId;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/payment/PaymentSuccessEvent.java
@@ -7,4 +7,9 @@ import lombok.Getter;
 @Getter
 public class PaymentSuccessEvent {
     private Long paymentId;
+    private Long orderId;
+    private Long userId;
+    private String orderUuid;
+    private Long totalPrice;
+    private String paymentMethod;
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeTest.java
@@ -55,7 +55,7 @@ class LikeFacadeTest {
         @DisplayName("동일한 상품에 대해 여러 명이 좋아요 요청을 해도 상품의 좋아요 개수가 정상 반영되어야 한다.")
         @Nested
         class ConcurrencyCondition {
-            private final int SIZE = 50;
+            private final int SIZE = 30;
             private ProductEntity productEntity;
             private List<UserEntity> userEntityList;
 
@@ -145,7 +145,7 @@ class LikeFacadeTest {
         @DisplayName("동일한 상품에 대해 여러 명이 좋아요 취소 요청을 해도 상품의 좋아요 개수가 정상 반영되어야 한다.")
         @Nested
         class ConcurrencyCondition {
-            private final int SIZE = 300;
+            private final int SIZE = 50;
             private ProductEntity productEntity;
             private List<UserEntity> userEntityList;
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
@@ -261,7 +261,7 @@ class OrderFacadeTest {
             productEntity = productRepository.save(productEntity);
 
             List<OrderV1Dto.OrderRequest> requestList = new ArrayList<>();
-            int SIZE = 50;
+            int SIZE = 7;
             int totalQuantity = 0;
             for (int i = 1; i <= SIZE; i++) {
                 List<OrderV1Dto.ProductOrderRequest> items = List.of(new OrderV1Dto.ProductOrderRequest(productEntity.getId(), (long) i));
@@ -269,7 +269,6 @@ class OrderFacadeTest {
                 requestList.add(new OrderV1Dto.OrderRequest(items, 500L * i, null, payment));
                 totalQuantity += i;
             }
-
 
             // act
             ExecutorService executor = Executors.newFixedThreadPool(SIZE);
@@ -315,7 +314,7 @@ class OrderFacadeTest {
         @Test
         void successQuantityUse_whenConcurrencyOrder() throws InterruptedException {
             // arrange
-            int SIZE = 200;
+            int SIZE = 10;
             final long userDefaultPoint = 15000000L;
             final long productDefaultQuantity = 30000L;
             List<UserEntity> userEntityList = new ArrayList<>();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -119,7 +119,7 @@ class OrderServiceIntegrationTest {
                 // arrange
 
                 // act
-                OrderEntity orderEntity = orderService.order(userEntity, itemList, TOTAL_PRICE, null);
+                OrderEntity orderEntity = orderService.createOrder(userEntity, itemList, TOTAL_PRICE, null);
 
                 // assert
                 assertAll(
@@ -136,7 +136,7 @@ class OrderServiceIntegrationTest {
                 // arrange
 
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(null, itemList, TOTAL_PRICE, null));
+                CoreException exception = assertThrows(CoreException.class, () -> orderService.createOrder(null, itemList, TOTAL_PRICE, null));
 
                 // assert
                 assertAll(
@@ -151,7 +151,7 @@ class OrderServiceIntegrationTest {
                 // arrange
 
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(userEntity, new ArrayList<>(), TOTAL_PRICE, null));
+                CoreException exception = assertThrows(CoreException.class, () -> orderService.createOrder(userEntity, new ArrayList<>(), TOTAL_PRICE, null));
 
                 // assert
                 assertAll(
@@ -166,7 +166,7 @@ class OrderServiceIntegrationTest {
                 // arrange
 
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(userEntity, itemList, -1L, null));
+                CoreException exception = assertThrows(CoreException.class, () -> orderService.createOrder(userEntity, itemList, -1L, null));
 
                 // assert
                 assertAll(

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -3,7 +3,6 @@ package com.loopers.domain.order;
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.OrderInfo;
-import com.loopers.application.payment.PaymentCommand;
 import com.loopers.domain.coupon.CouponEntity;
 import com.loopers.domain.coupon.CouponRepository;
 import com.loopers.domain.coupon.UserCouponEntity;
@@ -118,10 +117,9 @@ class OrderServiceIntegrationTest {
             @Test
             void success_order() {
                 // arrange
-                PaymentCommand.Payment payment = new PaymentCommand.Payment("POINT", TOTAL_PRICE, null);
 
                 // act
-                OrderEntity orderEntity = orderService.order(userEntity, itemList, TOTAL_PRICE, null, payment);
+                OrderEntity orderEntity = orderService.order(userEntity, itemList, TOTAL_PRICE, null);
 
                 // assert
                 assertAll(
@@ -136,10 +134,9 @@ class OrderServiceIntegrationTest {
             @Test
             void throws401Exception_whenUserIsNull() {
                 // arrange
-                PaymentCommand.Payment payment = new PaymentCommand.Payment("POINT", TOTAL_PRICE, null);
 
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(null, itemList, TOTAL_PRICE, null, payment));
+                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(null, itemList, TOTAL_PRICE, null));
 
                 // assert
                 assertAll(
@@ -152,10 +149,9 @@ class OrderServiceIntegrationTest {
             @Test
             void throws400Exception_whenOrderProductListIsEmpty() {
                 // arrange
-                PaymentCommand.Payment payment = new PaymentCommand.Payment("POINT", TOTAL_PRICE, null);
 
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(userEntity, new ArrayList<>(), TOTAL_PRICE, null, payment));
+                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(userEntity, new ArrayList<>(), TOTAL_PRICE, null));
 
                 // assert
                 assertAll(
@@ -168,10 +164,9 @@ class OrderServiceIntegrationTest {
             @Test
             void throws400Exception_whenOrderPriceIsLessThan0() {
                 // arrange
-                PaymentCommand.Payment payment = new PaymentCommand.Payment("POINT", TOTAL_PRICE, null);
 
                 // act
-                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(userEntity, itemList, -1L, null, payment));
+                CoreException exception = assertThrows(CoreException.class, () -> orderService.order(userEntity, itemList, -1L, null));
 
                 // assert
                 assertAll(

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -58,8 +58,10 @@ spring:
 datasource:
   mysql-jpa:
     main:
-      maximum-pool-size: 10
-      minimum-idle: 5
+      maximum-pool-size: 50
+      minimum-idle: 20
+      connection-timeout: 10000
+      leak-detection-threshold: 60000
 
 ---
 spring.config.activate.on-profile: dev
@@ -74,7 +76,7 @@ datasource:
       jdbc-url: jdbc:mysql://localhost:13306/loopers
       username: application
       password: application
-      
+
 ---
 spring.config.activate.on-profile: qa
 


### PR DESCRIPTION
## 📌 Summary
- 주문 처리 시 쿠폰 사용/결제 처리를 이벤트로 분리
- 결과 데이터 플랫폼에 전송 (단순 text, 추후 수정)
- 쿠폰사용실패, 결제성공, 결제실패, 주문성공, 주문실패에 대한 핸들링
- 좋아요/좋아요 취소에 대해 상품 좋아요 수 집계 처리를 이벤트로 분리
- 기존 테스트 통과 확인

## 💬 Review Points
(1) 이벤트 처리 시, before_commit 과 after_commit 의 기준을 사실 잘 모르겠습니다. 쿠폰 사용의 경우 하나의 쿠폰의 여러 주문에서 사용하면 안될 것 같다는 판단 하에 before_commit으로 두고, 나머지 작업들은 after_commit으로 두었는데, 혹시 모든 이벤트를 after_commit으로 변경하여야 할까요 ?
(2) 집계성 데이터들은 이벤트로 처리해서 트랜젝션을 짧게 가져가는 게 좋은 것 같습니다. 근데 만약에 해당 이벤트가 실패할 수 있다고 생각합니다. 그런 경우에는 일배치를 돌려서 좋아요의 정합성을 맞춰주는 편이신가요, 아니면 실패에 대한 이벤트도 발행하여 처리하나요 ?
(3) 트랜젝션을 분리하여 하나의 트랜잭션을 작게 나누어주고, 하나의 메인 트랜젝션에서 굳이 처리하지 않아도 되는 이벤트를 분리하면 되는 것으로 이해했습니다. 하지만 지금은 요구사항이 있어서 그거에 맞춰서 하긴 했는데 이게 실무로 넘어가면 그 경계를 잘 모르겠습니다.
이런 건 프로젝트마다 다를까요? 예를 들어 로그를 찍는 이벤트가 있다고 할 때, 어떤 서비스에서는 로그는 부수적인 거라 이벤트로 분리한다면, 이력을 위한 서비스의 경우에는(로그로 감사행위를 하여 로그가 중요함) 추가로그/변경로그에서 로그는 메인 로직에 해당하니까 이벤트로 분리안하고 하나의 트랜젝션에서 실행하면 되는 거라고 이해하면 될까요 ?

## ✅ Checklist
### 🧾 주문 ↔ 결제
- [x]  **이벤트 기반**으로 주문 트랜잭션과 쿠폰 사용 처리를 분리한다.
- [x]  **이벤트 기반**으로 결제 결과에 따른 주문 처리를 분리한다.
- [x]  **이벤트 기반**으로 주문, 결제의 결과에 대한 데이터 플랫폼에 전송하는 후속처리를 진행한다. => 우선적으로 로그만 찍었습니다. 사실 정확하게 어떤 게 있어야할 지 모르겠습니다. 일단 전송만 하고 나중에 그 데이터를 이용해서 무언가 작업을 해야할 때 수정할 예정입니다.ㅎㅎ

### ❤️ 좋아요 ↔ 집계
- [x]  **이벤트 기반**으로 좋아요 처리와 집계를 분리한다.
- [x]  집계 로직의 성공/실패와 상관 없이, 좋아요 처리는 정상적으로 완료되어야 한다.

### 📽️ 공통
- [x]  이벤트 기반으로 `유저의 행동` 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.
- [x]  동작의 주체를 적절하게 분리하고, 트랜잭션 간의 연관관계를 고민해 봅니다.

## 📎 References