### PR TITLE
[Round 9] 랭킹시스템 적용하기

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -14,7 +14,9 @@ import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.order.OrderV1Dto;
 import com.loopers.interfaces.listener.coupon.UserCouponUseEvent;
+import com.loopers.interfaces.listener.order.OrderCompletedEvent;
 import com.loopers.interfaces.listener.payment.PaymentCreateEvent;
+import com.loopers.kafka.message.payload.OrderEventPayload;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
@@ -83,6 +85,14 @@ public class OrderFacade {
             eventPublisher.publish(new UserCouponUseEvent(orderEntity.getPayment().getId(), orderEntity.getUserCoupon().getId(), orderEntity.getTotalPrice(), orderEntity.getId(), LocalDateTime.now()));
         }
 
+        List<OrderEventPayload.OrderItem> orderItems = itemList.stream()
+                .map(item -> OrderEventPayload.OrderItem.builder()
+                        .productId(item.productEntity().getId())
+                        .quantity(item.quantity())
+                        .price(item.productEntity().getPrice())
+                        .build())
+                .toList();
+
         // 8. 결제
         eventPublisher.publish(new PaymentCreateEvent(
                 orderEntity.getUser().getId(),
@@ -92,8 +102,8 @@ public class OrderFacade {
                 orderEntity.getId(),
                 LocalDateTime.now()
         ));
-
-//        eventPublisher.publish(DataPlatformSendEvent.orderComplete(orderEntity.getId(), user.getId(), orderEntity.getUuid(), orderEntity.getTotalPrice()));
+        OrderCompletedEvent e = new OrderCompletedEvent(orderEntity.getId(), user.getLoginId(), orderEntity.getUuid(), orderEntity.getTotalPrice(), orderItems, LocalDateTime.now());
+        eventPublisher.publish(e);
         return OrderInfo.from(orderEntity);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -1,5 +1,6 @@
 package com.loopers.application.product;
 
+import com.loopers.application.event.EventPublisher;
 import com.loopers.domain.like.LikeEntity;
 import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.BrandEntity;
@@ -7,11 +8,14 @@ import com.loopers.domain.product.BrandService;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.listener.product.ProductViewEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.GlobalErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -23,7 +27,9 @@ public class ProductFacade {
     private final ProductService productService;
     private final LikeService likeService;
     private final BrandService brandService;
+    private final EventPublisher eventPublisher;
 
+    @Transactional
     public ProductInfo getProductInfo(String userId, Long productId) {
         if (productId == null) {
             throw new CoreException(GlobalErrorType.BAD_REQUEST, "상품 ID가 존재하지 않습니다.");
@@ -41,7 +47,7 @@ public class ProductFacade {
             Optional<LikeEntity> optionalLikeEntity = likeService.getUserLikeProduct(optionalUserEntity.get().getId(), productId);
             isLike = optionalLikeEntity.isPresent() && optionalLikeEntity.get().getIsLike();
         }
-
+        eventPublisher.publish(new ProductViewEvent(productId, userId, LocalDateTime.now()));
         return ProductInfo.from(productCacheDto, isLike);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -6,6 +6,7 @@ import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.BrandEntity;
 import com.loopers.domain.product.BrandService;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.ranking.RankingService;
 import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.listener.product.ProductViewEvent;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +29,7 @@ public class ProductFacade {
     private final ProductService productService;
     private final LikeService likeService;
     private final BrandService brandService;
+    private final RankingService rankingService;
     private final EventPublisher eventPublisher;
 
     @Transactional
@@ -47,8 +50,12 @@ public class ProductFacade {
             Optional<LikeEntity> optionalLikeEntity = likeService.getUserLikeProduct(optionalUserEntity.get().getId(), productId);
             isLike = optionalLikeEntity.isPresent() && optionalLikeEntity.get().getIsLike();
         }
+
+        Long rank = rankingService.getRank(LocalDate.now(), productId);
+        Double score = rankingService.getScore(LocalDate.now(), productId);
+
         eventPublisher.publish(new ProductViewEvent(productId, userId, LocalDateTime.now()));
-        return ProductInfo.from(productCacheDto, isLike);
+        return ProductInfo.from(productCacheDto, isLike, rank, score);
     }
 
     public List<ProductInfo> getProductInfoList(String userId, Long brandId, ProductSortOrder order, Integer size, Integer page) {
@@ -69,14 +76,16 @@ public class ProductFacade {
 
         List<ProductCacheDto> productCacheDtoList = productService.getProductInfoList(optionalBrandEntity, order, size, page);
         List<ProductInfo> productInfoList = new ArrayList<>();
-        if (optionalUserEntity.isPresent()) {
-            for (ProductCacheDto productCacheDto : productCacheDtoList) {
-                Optional<LikeEntity> optionalLikeEntity = likeService.getUserLikeProduct(optionalUserEntity.get().getId(), productCacheDto.getId());
-                productInfoList.add(ProductInfo.from(productCacheDto, optionalLikeEntity.isPresent() && optionalLikeEntity.get().getIsLike()));
+        for (ProductCacheDto productCacheDto : productCacheDtoList) {
+            Optional<LikeEntity> optionalLikeEntity = Optional.empty();
+            if (optionalUserEntity.isPresent()) {
+                optionalLikeEntity = likeService.getUserLikeProduct(optionalUserEntity.get().getId(), productCacheDto.getId());
             }
-        } else {
-            productInfoList = productCacheDtoList.stream().map(ProductInfo::from).toList();
+            Long rank = rankingService.getRank(LocalDate.now(), productCacheDto.getId());
+            Double score = rankingService.getScore(LocalDate.now(), productCacheDto.getId());
+            productInfoList.add(ProductInfo.from(productCacheDto, optionalLikeEntity.isPresent() && optionalLikeEntity.get().getIsLike(), rank, score));
         }
         return productInfoList;
     }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -4,17 +4,23 @@ import com.loopers.domain.product.ProductEntity;
 
 public record ProductInfo(Long id, String name, Boolean isLike, BrandInfo brandInfo, Long price, Long quantity,
                           String description,
-                          Long totalLikes) {
+                          Long totalLikes, Long rank, Double score) {
+
+    public static ProductInfo from(ProductEntity productEntity, Boolean userLike, Long rank, Double score) {
+        // 일단 좋아요는 false 처리 -> 기능 구현 후 수정
+        return new ProductInfo(productEntity.getId(), productEntity.getName(), userLike, BrandInfo.from(productEntity.getBrand()), productEntity.getPrice(), productEntity.getQuantity(), productEntity.getDescription(), productEntity.getProductCount().getLikeCount(), rank, score);
+    }
+
     public static ProductInfo from(ProductEntity productEntity, Boolean userLike) {
         // 일단 좋아요는 false 처리 -> 기능 구현 후 수정
-        return new ProductInfo(productEntity.getId(), productEntity.getName(), userLike, BrandInfo.from(productEntity.getBrand()), productEntity.getPrice(), productEntity.getQuantity(), productEntity.getDescription(), productEntity.getProductCount().getLikeCount());
+        return new ProductInfo(productEntity.getId(), productEntity.getName(), userLike, BrandInfo.from(productEntity.getBrand()), productEntity.getPrice(), productEntity.getQuantity(), productEntity.getDescription(), productEntity.getProductCount().getLikeCount(), null, null);
     }
 
     public static ProductInfo from(ProductEntity productEntity) {
-        return new ProductInfo(productEntity.getId(), productEntity.getName(), false, BrandInfo.from(productEntity.getBrand()), productEntity.getPrice(), productEntity.getQuantity(), productEntity.getDescription(), productEntity.getProductCount().getLikeCount());
+        return new ProductInfo(productEntity.getId(), productEntity.getName(), false, BrandInfo.from(productEntity.getBrand()), productEntity.getPrice(), productEntity.getQuantity(), productEntity.getDescription(), productEntity.getProductCount().getLikeCount(), null, null);
     }
 
-    public static ProductInfo from(ProductCacheDto cacheDto, Boolean userLike) {
+    public static ProductInfo from(ProductCacheDto cacheDto, Boolean userLike, Long rank, Double score) {
         return new ProductInfo(
                 cacheDto.getId(),
                 cacheDto.getName(),
@@ -23,11 +29,14 @@ public record ProductInfo(Long id, String name, Boolean isLike, BrandInfo brandI
                 cacheDto.getPrice(),
                 cacheDto.getQuantity(),
                 cacheDto.getDescription(),
-                cacheDto.getLikeCount()
+                cacheDto.getLikeCount(),
+                rank,
+                score
+
         );
     }
 
     public static ProductInfo from(ProductCacheDto cacheDto) {
-        return from(cacheDto, false);
+        return from(cacheDto, false, null, null);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,61 @@
+package com.loopers.application.ranking;
+
+import com.loopers.application.product.ProductInfo;
+import com.loopers.domain.like.LikeEntity;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.ranking.RankingService;
+import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class RankingFacade {
+
+    private final RankingService rankingService;
+    private final ProductService productService;
+    private final UserService userService;
+    private final LikeService likeService;
+
+    @Transactional(readOnly = true)
+    public List<ProductInfo> getRankingList(String userId, LocalDate date, Integer page, Integer size) {
+        if (date == null) {
+            date = LocalDate.now();
+        }
+        if (page < 1) page = 1;
+        if (size < 1 || size > 100) size = 20;
+        List<Long> productIdList = rankingService.getTopProductIds(date, page, size);
+        List<ProductEntity> productEntityList = productService.getProductList(productIdList);
+        Optional<UserEntity> optionalUserEntity = userService.getUserInfo(userId);
+
+        if (optionalUserEntity.isEmpty()) {
+            List<ProductInfo> productInfoList = new ArrayList<>();
+            for (ProductEntity product : productEntityList) {
+                Long rank = rankingService.getRank(date, product.getId());
+                Double score = rankingService.getScore(date, product.getId());
+                productInfoList.add(ProductInfo.from(product, false, rank, score));
+            }
+            return productInfoList;
+        } else {
+            List<ProductInfo> productInfoList = new ArrayList<>();
+            for (ProductEntity product : productEntityList) {
+                boolean isLike = false;
+                Optional<LikeEntity> optionalLikeEntity = likeService.getUserLikeProduct(optionalUserEntity.get().getId(), product.getId());
+                isLike = optionalLikeEntity.isPresent() && optionalLikeEntity.get().getIsLike();
+                Long rank = rankingService.getRank(date, product.getId());
+                Double score = rankingService.getScore(date, product.getId());
+                productInfoList.add(ProductInfo.from(product, isLike, rank, score));
+            }
+            return productInfoList;
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -37,16 +37,14 @@ public class RankingFacade {
         List<ProductEntity> productEntityList = productService.getProductList(productIdList);
         Optional<UserEntity> optionalUserEntity = userService.getUserInfo(userId);
 
+        List<ProductInfo> productInfoList = new ArrayList<>();
         if (optionalUserEntity.isEmpty()) {
-            List<ProductInfo> productInfoList = new ArrayList<>();
             for (ProductEntity product : productEntityList) {
                 Long rank = rankingService.getRank(date, product.getId());
                 Double score = rankingService.getScore(date, product.getId());
                 productInfoList.add(ProductInfo.from(product, false, rank, score));
             }
-            return productInfoList;
         } else {
-            List<ProductInfo> productInfoList = new ArrayList<>();
             for (ProductEntity product : productEntityList) {
                 boolean isLike = false;
                 Optional<LikeEntity> optionalLikeEntity = likeService.getUserLikeProduct(optionalUserEntity.get().getId(), product.getId());
@@ -55,7 +53,8 @@ public class RankingFacade {
                 Double score = rankingService.getScore(date, product.getId());
                 productInfoList.add(ProductInfo.from(product, isLike, rank, score));
             }
-            return productInfoList;
         }
+        productInfoList = productInfoList.stream().sorted((o1, o2) -> o1.rank().compareTo(o2.rank())).toList();
+        return productInfoList;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -17,4 +17,6 @@ public interface ProductRepository {
     List<ProductEntity> saveAll(List<ProductEntity> productEntityList);
 
     Optional<ProductEntity> getProductInfoWithLock(Long productId);
+
+    List<ProductEntity> findAllByIdIn(List<Long> productIdList);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -17,6 +17,6 @@ public interface ProductRepository {
     List<ProductEntity> saveAll(List<ProductEntity> productEntityList);
 
     Optional<ProductEntity> getProductInfoWithLock(Long productId);
-
+    
     List<ProductEntity> findAllByIdIn(List<Long> productIdList);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -93,4 +93,9 @@ public class ProductService {
         }
         return productEntity;
     }
+
+    @Transactional
+    public List<ProductEntity> getProductList(List<Long> productIdList) {
+        return productRepository.findAllByIdIn(productIdList);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RankingRepository {
+    /**
+     * 특정 상품의 순위 조회 (1부터 시작, 없으면 null)
+     */
+    Long getProductRank(LocalDate date, Long productId);
+
+    /**
+     * 상위 N개 상품 ID 조회 (페이징)
+     */
+    List<Long> getTopProductIdList(LocalDate date, int offset, int limit);
+
+    /**
+     * 특정 상품의 특정 날짜 점수 조회
+     */
+    Double getScore(LocalDate date, Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,39 @@
+package com.loopers.domain.ranking;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+
+    /**
+     * 특정 날짜의 상위 랭킹 상품 ID 조회 (페이징)
+     */
+    public List<Long> getTopProductIds(LocalDate date, int page, int size) {
+        int offset = (page - 1) * size;
+        return rankingRepository.getTopProductIdList(date, offset, size);
+    }
+
+    /**
+     * 특정 상품의 특정 날짜 순위 조회 (1부터 시작)
+     */
+    public Long getRank(LocalDate date, Long productId) {
+        return rankingRepository.getProductRank(date, productId);
+    }
+
+    /**
+     * 특정 상품의 특정 날짜 점수 조회
+     */
+    public Double getScore(LocalDate date, Long productId) {
+        return rankingRepository.getScore(date, productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long> {
@@ -18,4 +19,8 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
     @EntityGraph(attributePaths = {"productCount", "brand"})
     @Query("SELECT p FROM ProductEntity p WHERE p.id = :id")
     Optional<ProductEntity> getProductInfoWithLock(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {"productCount", "brand"})
+    @Query("SELECT p FROM ProductEntity p WHERE p.id in :list")
+    List<ProductEntity> findAllByIdIn(@Param("list") List<Long> productIdList);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -43,4 +43,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public Optional<ProductEntity> getProductInfoWithLock(Long productId) {
         return productJpaRepository.getProductInfoWithLock(productId);
     }
+
+    @Override
+    public List<ProductEntity> findAllByIdIn(List<Long> productIdList) {
+        return productJpaRepository.findAllByIdIn(productIdList);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RedisRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RedisRankingRepository.java
@@ -1,0 +1,85 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisRankingRepository implements RankingRepository {
+
+    private static final String KEY_PREFIX = "loopers:rank:product:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long TTL_DAYS = 2;
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public Long getProductRank(LocalDate date, Long productId) {
+        String key = generateKey(date);
+        String productIdString = productId.toString();
+
+        try {
+            Long rank = stringRedisTemplate.opsForZSet().reverseRank(key, productIdString);
+            return rank != null ? rank + 1 : null; // 1부터 시작, 없으면 null
+
+        } catch (Exception e) {
+            log.error("상품 순위 조회 실패 - date: {}, productId: {}", date, productId, e);
+            return null;
+        }
+    }
+
+    @Override
+    public List<Long> getTopProductIdList(LocalDate date, int offset, int limit) {
+        String key = generateKey(date);
+
+        try {
+            Set<String> topProductList = stringRedisTemplate.opsForZSet()
+                    .reverseRange(key, offset, offset + limit - 1);
+
+            List<Long> productIdList = new ArrayList<>();
+            log.info("=====디버깅===");
+            log.info("생성된 키: {}", key);
+            log.info("조회 파라미터 - date: {}, offset: {}, limit: {}", date, offset, limit);
+
+            if (topProductList != null) {
+                for (String productId : topProductList) {
+                    try {
+                        productIdList.add(Long.parseLong(productId));
+                    } catch (NumberFormatException e) {
+                        log.warn("잘못된 상품 ID 형식: {}", productId);
+                    }
+                }
+            }
+
+            return productIdList;
+
+        } catch (Exception e) {
+            log.error("상위 상품 ID 조회 실패 - date: {}, offset: {}, limit: {}", date, offset, limit, e);
+            return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public Double getScore(LocalDate date, Long productId) {
+        String key = generateKey(date);
+        String productIdString = String.valueOf(productId);
+
+        Double score = stringRedisTemplate.opsForZSet().score(key, productIdString);
+        return score != null ? score : 0.0;
+    }
+
+    private String generateKey(LocalDate date) {
+        return KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,14 +1,16 @@
 package com.loopers.interfaces.api.product;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.loopers.application.product.BrandInfo;
 import com.loopers.application.product.ProductInfo;
 
 public class ProductV1Dto {
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     public record ProductResponse(Long id, String name, Boolean isLike, BrandInfo brandInfo, Long price, String description,
-                                  Long totalLikes) {
+                                  Long totalLikes, Long rank, Double score) {
         public ProductResponse(Long id, String name, Boolean isLike, BrandInfo brandInfo, Long price, String description,
-                               Long totalLikes) {
+                               Long totalLikes, Long rank, Double score) {
             this.id = id;
             this.name = name;
             this.isLike = isLike;
@@ -16,11 +18,13 @@ public class ProductV1Dto {
             this.price = price;
             this.description = description;
             this.totalLikes = totalLikes;
+            this.rank = rank;
+            this.score = score;
         }
 
         public static ProductResponse from(ProductInfo productInfo) {
             return new ProductResponse(productInfo.id(), productInfo.name(), productInfo.isLike(), productInfo.brandInfo(), productInfo.price(), productInfo.description()
-                    , productInfo.totalLikes());
+                    , productInfo.totalLikes(), productInfo.rank(), productInfo.score());
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.product.ProductV1Dto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Ranking V1 API", description = "Ranking API")
+public interface RankingV1ApiSpec {
+
+    @Operation(
+            summary = "랭킹 조회",
+            description = "랭킹 리스트를 조회합니다."
+    )
+    ApiResponse<List<ProductV1Dto.ProductResponse>> getProductRankingList(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
+            @RequestParam(value = "page", defaultValue = "1") Integer page
+    );
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.product.ProductV1Dto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/rankings")
+public class RankingV1Controller implements RankingV1ApiSpec {
+
+    private final RankingFacade rankingFacade;
+
+    @Override
+    @GetMapping
+    public ApiResponse<List<ProductV1Dto.ProductResponse>> getProductRankingList(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
+            @RequestParam(value = "page", defaultValue = "1") Integer page
+    ) {
+        List<ProductInfo> response = rankingFacade.getRankingList(userId, date, page, size);
+        return ApiResponse.success(response.stream().map(ProductV1Dto.ProductResponse::from).toList());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderCreatedEvent.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @AllArgsConstructor
 @Getter
-public class OrderCompletedEvent implements Event {
+public class OrderCreatedEvent implements Event {
 
     private Long orderId;
     private String userId;
@@ -28,4 +28,6 @@ public class OrderCompletedEvent implements Event {
     public String getAggregateId() {
         return String.valueOf(orderId);
     }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/order/OrderEventListener.java
@@ -1,6 +1,5 @@
 package com.loopers.interfaces.listener.order;
 
-import com.loopers.interfaces.listener.dataplatform.DataPlatformSendEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,15 +16,15 @@ public class OrderEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderCompleted(OrderCompletedEvent event) {
-        log.info("주문 완료 이벤트 처리: orderId={}", event.orderId());
+        log.info("주문 완료 이벤트 처리: orderId={}", event.getAggregateId());
 
         // 데이터 플랫폼 전송 이벤트 발행
-        eventPublisher.publishEvent(DataPlatformSendEvent.orderComplete(
-                event.orderId(),
-                event.userId(),
-                event.orderUuid(),
-                event.totalPrice()
-        ));
+//        eventPublisher.publishEvent(DataPlatformSendEvent.orderComplete(
+//                event.ge(),
+//                event.userId(),
+//                event.orderUuid(),
+//                event.totalPrice()
+//        ));
 
         // 사용자 행동 로깅 이벤트도 발행 가능
 //        eventPublisher.publishEvent(new UserActionEvent("ORDER_COMPLETE", event.userId(), event.orderId()));

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/product/ProductViewEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/product/ProductViewEvent.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.listener.product;
+
+import com.loopers.application.event.Event;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ProductViewEvent implements Event {
+
+    private Long productId;
+    private String userId;
+    private LocalDateTime createdAt;
+
+    @Override
+    public LocalDateTime getOccurredAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String getAggregateId() {
+        return String.valueOf(productId);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventHandled.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventHandled.java
@@ -68,6 +68,7 @@ public class EventHandled {
                 .aggregateId(aggregateId)
                 .eventVersion(eventVersion)
                 .processedAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventLog.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventLog.java
@@ -73,6 +73,7 @@ public class EventLog {
                 .offsetValue(offsetValue)
                 .payload(payload)
                 .eventTimestamp(eventTimestamp)
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -51,11 +51,19 @@ public class ProductMetrics {
     @Builder.Default
     private Long salesQuantity = 0L;
 
+    @Column(name = "view_count", nullable = false)
+    @Builder.Default
+    private Long viewCount = 0L;
+
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     // 비즈니스 메서드
+    public void view() {
+        this.viewCount++;
+    }
+
     public void addLike() {
         this.likeCount++;
     }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+
+public interface RankingRepository {
+    /**
+     * 랭킹 점수 추가/업데이트
+     */
+    void incrementScore(LocalDate date, Long productId, double score);
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,158 @@
+package com.loopers.domain.ranking;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.kafka.message.KafkaEventMessage;
+import com.loopers.kafka.message.payload.OrderEventPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    // 가중치 설정
+    private static final double VIEW_WEIGHT = 0.1;
+    private static final double LIKE_WEIGHT = 0.2;
+    private static final double ORDER_WEIGHT = 0.6;
+
+    private final RankingRepository rankingRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 조회 점수 추가
+     */
+    public void addViewScore(KafkaEventMessage<?> message) {
+        try {
+            Map<String, Object> payload = (Map<String, Object>) message.getPayload();
+            Long productId = getFieldAsLong(payload, "productId");
+
+            if (productId == null) {
+                log.warn("productId가 없습니다 - eventId: {}", message.getEventId());
+                return;
+            }
+
+            double score = VIEW_WEIGHT * 1; // 0.1 * 1
+            rankingRepository.incrementScore(LocalDate.now(), productId, score);
+
+            log.debug("조회 랭킹 점수 추가 - productId: {}, score: {}", productId, score);
+
+        } catch (Exception e) {
+            log.error("조회 랭킹 점수 추가 실패", e);
+        }
+    }
+
+    /**
+     * 좋아요 점수 추가
+     */
+    public void addLikeScore(KafkaEventMessage<?> message) {
+        try {
+            Map<String, Object> payload = (Map<String, Object>) message.getPayload();
+            Long productId = getFieldAsLong(payload, "productId");
+
+            if (productId == null) {
+                log.warn("productId가 없습니다 - eventId: {}", message.getEventId());
+                return;
+            }
+
+            double score = LIKE_WEIGHT * 1; // 0.2 * 1
+            rankingRepository.incrementScore(LocalDate.now(), productId, score);
+
+            log.debug("좋아요 랭킹 점수 추가 - productId: {}, score: {}", productId, score);
+
+        } catch (Exception e) {
+            log.error("좋아요 랭킹 점수 추가 실패", e);
+        }
+    }
+
+    /**
+     * 좋아요 점수 차감
+     */
+    public void removeLikeScore(KafkaEventMessage<?> message) {
+        try {
+            Map<String, Object> payload = (Map<String, Object>) message.getPayload();
+            Long productId = getFieldAsLong(payload, "productId");
+
+            if (productId == null) {
+                log.warn("productId가 없습니다 - eventId: {}", message.getEventId());
+                return;
+            }
+
+            double score = -(LIKE_WEIGHT * 1); // -0.2 * 1
+            rankingRepository.incrementScore(LocalDate.now(), productId, score);
+
+            log.debug("좋아요 취소 랭킹 점수 차감 - productId: {}, score: {}", productId, score);
+
+        } catch (Exception e) {
+            log.error("좋아요 취소 랭킹 점수 처리 실패", e);
+        }
+    }
+
+    /**
+     * 주문 점수 추가
+     */
+    public void addOrderScore(KafkaEventMessage<?> message) {
+        try {
+//            Map<String, Object> payload = (Map<String, Object>) message.getPayload();
+
+            // OrderCompletedEvent에서 orderItems 추출
+            OrderEventPayload.OrderCreated payload =
+                    objectMapper.convertValue(message.getPayload(), OrderEventPayload.OrderCreated.class);
+
+            if (payload.getOrderItems() == null || payload.getOrderItems().isEmpty()) {
+                log.warn("orderItems가 없습니다 - eventId: {}", message.getEventId());
+                return;
+            }
+
+            for (OrderEventPayload.OrderItem item : payload.getOrderItems()) {
+                Long productId = item.getProductId();
+                Long price = item.getPrice();
+                Long quantity = item.getQuantity();
+
+                if (productId == null || price == null || quantity == null) {
+                    log.warn("주문 아이템 정보 부족 - productId: {}, price: {}, quantity: {}",
+                            productId, price, quantity);
+                    continue;
+                }
+
+                // 주문 점수: 0.6 * log(price * quantity)
+                double orderValue = price * quantity;
+                double normalizedValue = Math.log10(orderValue + 1); // +1은 log(0) 방지
+                double score = ORDER_WEIGHT * normalizedValue;
+
+                rankingRepository.incrementScore(LocalDate.now(), productId, score);
+
+                log.debug("주문 랭킹 점수 추가 - productId: {}, orderValue: {}, score: {}",
+                        productId, orderValue, score);
+            }
+
+        } catch (Exception e) {
+            log.error("주문 랭킹 점수 추가 실패", e);
+        }
+    }
+
+    private Long getFieldAsLong(Map<String, Object> map, String fieldName) {
+        Object value = map.get(fieldName);
+        if (value == null) return null;
+
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                log.warn("숫자 변환 실패 - field: {}, value: {}", fieldName, value);
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RedisRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RedisRankingRepository.java
@@ -1,0 +1,49 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisRankingRepository implements RankingRepository {
+
+    private static final String KEY_PREFIX = "loopers:rank:product:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long TTL_DAYS = 2;
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void incrementScore(LocalDate date, Long productId, double score) {
+        String key = generateKey(date);
+        String productIdString = productId.toString();
+
+        try {
+            // ZINCRBY로 점수 증가
+            stringRedisTemplate.opsForZSet().incrementScore(key, productIdString, score);
+
+            // TTL 설정 (키가 새로 생성되었을 때만)
+            if (stringRedisTemplate.getExpire(key) == -1) {
+                stringRedisTemplate.expire(key, TTL_DAYS, TimeUnit.DAYS);
+                log.debug("랭킹 키 TTL 설정 - key: {}", key);
+            }
+
+        } catch (Exception e) {
+            log.error("랭킹 점수 업데이트 실패 - date: {}, productId: {}, score: {}",
+                    date, productId, score, e);
+            throw new RuntimeException("랭킹 점수 업데이트 실패", e);
+        }
+    }
+
+    private String generateKey(LocalDate date) {
+        return KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/AuditLogConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/AuditLogConsumer.java
@@ -1,7 +1,6 @@
 package com.loopers.interfaces.consumer;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.event.EventHandled;
 import com.loopers.domain.event.EventHandledRepository;
@@ -31,32 +30,123 @@ public class AuditLogConsumer {
     private final ObjectMapper objectMapper;
     private final com.loopers.support.DlqPublisher dlqPublisher;
 
+//    @KafkaListener(
+//            topics = {KafkaTopics.CATALOG_EVENTS, KafkaTopics.ORDER_EVENTS},
+//            groupId = "audit-log-group",
+//            containerFactory = "kafkaListenerContainerFactory"
+//    )
+//    public void consume(
+//            String messageJson,
+//            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+//            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+//            @Header(KafkaHeaders.OFFSET) long offset,
+//            Acknowledgment ack
+//    ) throws JsonProcessingException {
+//        // JSON 파싱
+//        KafkaEventMessage<?> message = objectMapper.readValue(
+//                messageJson,
+//                objectMapper.getTypeFactory().constructParametricType(
+//                        KafkaEventMessage.class,
+//                        Object.class
+//                )
+//        );
+//
+//        String eventId = message.getEventId();
+//
+//        try {
+//            log.debug("이벤트 수신 - eventId: {}, type: {}, topic: {}",
+//                    eventId, message.getEventType(), topic);
+//
+//            // 1. 멱등성 체크
+//            if (eventHandledRepository.existsByEventIdAndConsumerName(eventId, CONSUMER_NAME)) {
+//                log.debug("이미 처리된 이벤트 스킵 - eventId: {}", eventId);
+//                ack.acknowledge();
+//                return;
+//            }
+//
+//            // 2. Version 체크 (순서가 뒤바뀐 이벤트 처리)
+//            Long eventVersion = message.getVersion() != null
+//                    ? message.getVersion().longValue()
+//                    : System.currentTimeMillis() / 1000;
+//
+//            Optional<EventHandled> latestProcessed = eventHandledRepository
+//                    .findLatestVersion(message.getAggregateId(), CONSUMER_NAME);
+//
+//            if (latestProcessed.isPresent() &&
+//                    latestProcessed.get().getEventVersion() >= eventVersion) {
+//                log.warn("구 버전 이벤트 스킵 - eventId: {}, version: {}, latestVersion: {}",
+//                        eventId, eventVersion, latestProcessed.get().getEventVersion());
+//                ack.acknowledge();
+//                return;
+//            }
+//
+//            // 3. EventLog 저장
+//            EventLog eventLog = EventLog.create(
+//                    eventId,
+//                    message.getEventType(),
+//                    message.getAggregateId(),
+//                    topic,
+//                    partition,
+//                    offset,
+//                    objectMapper.writeValueAsString(message.getPayload()),
+//                    message.getTimestamp()
+//            );
+//
+//            eventLogRepository.save(eventLog);
+//            log.info("이벤트 로그 저장 완료 - eventId: {}, type: {}",
+//                    eventId, message.getEventType());
+//
+//            // 4. 처리 완료 기록 (aggregateId와 version 포함)
+//            EventHandled eventHandled = EventHandled.create(
+//                    eventId,
+//                    CONSUMER_NAME,
+//                    message.getEventType(),
+//                    message.getAggregateId(),
+//                    eventVersion  // 추가
+//            );
+//
+//            eventHandledRepository.save(eventHandled);
+//
+//            // 5. ACK
+//            ack.acknowledge();
+//            log.debug("이벤트 처리 완료 및 ACK - eventId: {}", eventId);
+//
+//        } catch (Exception e) {
+//            log.error("이벤트 처리 실패 - eventId: {}, error: {}",
+//                    eventId, e.getMessage(), e);
+//
+//            // DLQ로 전송
+//            dlqPublisher.sendToDlq(
+//                    topic,  // 원본 토픽
+//                    messageJson,  // 원본 메시지
+//                    CONSUMER_NAME,  // 실패한 Consumer 이름
+//                    e.getMessage()  // 에러 메시지
+//            );
+//
+//            // ACK는 하되, DLQ로 보냈음을 표시
+//            ack.acknowledge();
+//        }
+//    }
+
     @KafkaListener(
             topics = {KafkaTopics.CATALOG_EVENTS, KafkaTopics.ORDER_EVENTS},
             groupId = "audit-log-group",
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void consume(
-            String messageJson,
+            KafkaEventMessage<?> message,  // String -> KafkaEventMessage로 변경
             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
             @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
             @Header(KafkaHeaders.OFFSET) long offset,
             Acknowledgment ack
-    ) throws JsonProcessingException {
-        // JSON 파싱
-        KafkaEventMessage<?> message = objectMapper.readValue(
-                messageJson,
-                objectMapper.getTypeFactory().constructParametricType(
-                        KafkaEventMessage.class,
-                        Object.class
-                )
-        );
-
+    ) {
         String eventId = message.getEventId();
 
         try {
             log.debug("이벤트 수신 - eventId: {}, type: {}, topic: {}",
                     eventId, message.getEventType(), topic);
+
+            // JSON 파싱 단계 제거 (이미 역직렬화됨)
 
             // 1. 멱등성 체크
             if (eventHandledRepository.existsByEventIdAndConsumerName(eventId, CONSUMER_NAME)) {
@@ -89,7 +179,7 @@ public class AuditLogConsumer {
                     topic,
                     partition,
                     offset,
-                    objectMapper.writeValueAsString(message.getPayload()),
+                    objectMapper.writeValueAsString(message.getPayload()), // payload만 JSON으로 변환
                     message.getTimestamp()
             );
 
@@ -103,7 +193,7 @@ public class AuditLogConsumer {
                     CONSUMER_NAME,
                     message.getEventType(),
                     message.getAggregateId(),
-                    eventVersion  // 추가
+                    eventVersion
             );
 
             eventHandledRepository.save(eventHandled);
@@ -117,14 +207,13 @@ public class AuditLogConsumer {
                     eventId, e.getMessage(), e);
 
             // DLQ로 전송
-            dlqPublisher.sendToDlq(
-                    topic,  // 원본 토픽
-                    messageJson,  // 원본 메시지
-                    CONSUMER_NAME,  // 실패한 Consumer 이름
-                    e.getMessage()  // 에러 메시지
-            );
+            try {
+                String messageJson = objectMapper.writeValueAsString(message);
+                dlqPublisher.sendToDlq(topic, messageJson, CONSUMER_NAME, e.getMessage());
+            } catch (Exception jsonError) {
+                log.error("DLQ 전송 중 JSON 변환 실패", jsonError);
+            }
 
-            // ACK는 하되, DLQ로 보냈음을 표시
             ack.acknowledge();
         }
     }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/DlqConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/DlqConsumer.java
@@ -25,48 +25,84 @@ public class DlqConsumer {
     private final ObjectMapper objectMapper;
     private final DeadLetterKafkaEventRepository deadLetterRepository;
 
+    //    @KafkaListener(
+//            topics = KafkaTopics.DLQ_TOPIC,
+//            groupId = "dlq-group",
+//            containerFactory = "dlqStringListenerContainerFactory"
+//    )
+//    public void consume(String messageJson, Acknowledgment ack) {
+//        try {
+//            log.info("DLQ 메시지 수신: {}", messageJson);
+//
+//            // 첫 번째 파싱: DLQ 메시지 구조
+//            Map<String, Object> dlqData = objectMapper.readValue(messageJson, Map.class);
+//
+//            String originalTopic = (String) dlqData.get("originalTopic");
+//            String originalMessageJson = (String) dlqData.get("originalMessage"); // 이미 JSON 문자열
+//            String consumerName = (String) dlqData.get("consumerName");
+//            String errorMessage = (String) dlqData.get("errorMessage");
+//            String failedAt = (String) dlqData.get("failedAt");
+//            Integer retryCount = (Integer) dlqData.getOrDefault("retryCount", 0);
+//
+//            // DB에 저장 (originalMessage는 이미 JSON 문자열이므로 그대로 저장)
+//            DeadLetterKafkaEvent deadLetter = DeadLetterKafkaEvent.create(
+//                    originalTopic,
+//                    originalMessageJson, // JSON 문자열 그대로
+//                    consumerName,
+//                    errorMessage,
+//                    retryCount
+//            );
+//
+//            deadLetterRepository.save(deadLetter);
+//
+//            log.warn("DLQ 메시지 DB 저장 완료 - topic: {}, consumer: {}, failedAt: {}",
+//                    originalTopic, consumerName, failedAt);
+//
+//            ack.acknowledge();
+//
+//        } catch (Exception e) {
+//            log.error("DLQ 메시지 처리 실패", e);
+//            ack.acknowledge();
+//        }
+//    }
     @KafkaListener(
             topics = KafkaTopics.DLQ_TOPIC,
             groupId = "dlq-group",
-            containerFactory = "kafkaListenerContainerFactory"
+            containerFactory = "dlqStringListenerContainerFactory"
     )
     public void consume(String messageJson, Acknowledgment ack) {
         try {
             log.info("DLQ 메시지 수신: {}", messageJson);
 
-            // DLQ 메시지 파싱
+            // TypeReference 사용해서 Map으로 파싱
             Map<String, Object> dlqData = objectMapper.readValue(
                     messageJson,
-                    new TypeReference<>() {
-                    }
+                    new TypeReference<Map<String, Object>>() {
+                    }  // 이렇게 수정
             );
 
             String originalTopic = (String) dlqData.get("originalTopic");
-            String originalMessage = (String) dlqData.get("originalMessage");
+            String originalMessageJson = (String) dlqData.get("originalMessage");
             String consumerName = (String) dlqData.get("consumerName");
             String errorMessage = (String) dlqData.get("errorMessage");
             Integer retryCount = (Integer) dlqData.getOrDefault("retryCount", 0);
 
-            // DB에 저장 (수동 재처리를 위해)
+            // DB 저장
             DeadLetterKafkaEvent deadLetter = DeadLetterKafkaEvent.create(
                     originalTopic,
-                    originalMessage,
+                    originalMessageJson,
                     consumerName,
                     errorMessage,
                     retryCount
             );
 
             deadLetterRepository.save(deadLetter);
-
-            log.warn("DLQ 메시지 DB 저장 완료 - topic: {}, consumer: {}",
-                    originalTopic, consumerName);
-
             ack.acknowledge();
 
         } catch (Exception e) {
             log.error("DLQ 메시지 처리 실패", e);
-            // DLQ 처리도 실패하면 로그만 남기고 ACK
             ack.acknowledge();
         }
     }
+
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -39,6 +39,7 @@ public class MetricsConsumer {
     private final ObjectMapper objectMapper;
     private final com.loopers.support.DlqPublisher dlqPublisher;
 
+
     @KafkaListener(
             topics = {KafkaTopics.CATALOG_EVENTS, KafkaTopics.ORDER_EVENTS},
             groupId = "metrics-batch-group",
@@ -46,7 +47,7 @@ public class MetricsConsumer {
     )
     @Transactional
     public void consumeBatch(
-            List<String> messages,
+            List<KafkaEventMessage<?>> messages,  // String -> KafkaEventMessage로 변경
             @Header(KafkaHeaders.RECEIVED_TOPIC) List<String> topics,
             Acknowledgment ack
     ) {
@@ -56,25 +57,18 @@ public class MetricsConsumer {
         int failedCount = 0;
 
         for (int i = 0; i < messages.size(); i++) {
-            String messageJson = messages.get(i);
-            String topic = topics.get(i);  // 같은 인덱스의 토픽
+            KafkaEventMessage<?> message = messages.get(i);  // 직접 사용
+            String topic = topics.get(i);
 
-            if (messageJson == null || messageJson.isEmpty()) {
+            if (message == null) {
                 log.warn("빈 메시지 스킵");
                 continue;
             }
 
             try {
-                // JSON 파싱
-                KafkaEventMessage<?> message = objectMapper.readValue(
-                        messageJson,
-                        objectMapper.getTypeFactory().constructParametricType(
-                                KafkaEventMessage.class,
-                                Object.class
-                        )
-                );
-
                 String eventId = message.getEventId();
+
+                // JSON 파싱 단계 제거 (이미 역직렬화됨)
 
                 // 1. 멱등성 체크
                 if (eventHandledRepository.existsByEventIdAndConsumerName(eventId, CONSUMER_NAME)) {
@@ -125,13 +119,13 @@ public class MetricsConsumer {
                 log.error("개별 메시지 처리 실패", e);
                 failedCount++;
 
-                // DLQ로 전송
-                dlqPublisher.sendToDlq(
-                        topic,
-                        messageJson,
-                        CONSUMER_NAME,
-                        e.getMessage()
-                );
+                // DLQ로 전송 - JSON 직렬화 필요
+                try {
+                    String messageJson = objectMapper.writeValueAsString(message);
+                    dlqPublisher.sendToDlq(topic, messageJson, CONSUMER_NAME, e.getMessage());
+                } catch (Exception jsonError) {
+                    log.error("DLQ 전송 중 JSON 변환 실패", jsonError);
+                }
             }
         }
 
@@ -139,6 +133,108 @@ public class MetricsConsumer {
         ack.acknowledge();
         log.info("배치 처리 완료 - 처리: {}/{} 건", processedCount, messages.size());
     }
+
+
+//    @KafkaListener(
+//            topics = {KafkaTopics.CATALOG_EVENTS, KafkaTopics.ORDER_EVENTS},
+//            groupId = "metrics-batch-group",
+//            containerFactory = "BATCH_LISTENER_DEFAULT"
+//    )
+//    @Transactional
+//    public void consumeBatch(
+//            List<String> messages,
+//            @Header(KafkaHeaders.RECEIVED_TOPIC) List<String> topics,
+//            Acknowledgment ack
+//    ) {
+//        log.info("배치 처리 시작 - {} 건", messages.size());
+//
+//        int processedCount = 0;
+//        int failedCount = 0;
+//
+//        for (int i = 0; i < messages.size(); i++) {
+//            String messageJson = messages.get(i);
+//            String topic = topics.get(i);  // 같은 인덱스의 토픽
+//
+//            if (messageJson == null || messageJson.isEmpty()) {
+//                log.warn("빈 메시지 스킵");
+//                continue;
+//            }
+//
+//            try {
+//                // JSON 파싱
+//                KafkaEventMessage<?> message = objectMapper.readValue(
+//                        messageJson,
+//                        objectMapper.getTypeFactory().constructParametricType(
+//                                KafkaEventMessage.class,
+//                                Object.class
+//                        )
+//                );
+//
+//                String eventId = message.getEventId();
+//
+//                // 1. 멱등성 체크
+//                if (eventHandledRepository.existsByEventIdAndConsumerName(eventId, CONSUMER_NAME)) {
+//                    log.debug("이미 처리된 이벤트 스킵 - eventId: {}", eventId);
+//                    continue;
+//                }
+//
+//                // 2. Version 체크
+//                Long eventVersion = message.getVersion() != null
+//                        ? message.getVersion().longValue()
+//                        : System.currentTimeMillis() / 1000;
+//
+//                Optional<EventHandled> latestProcessed = eventHandledRepository
+//                        .findLatestVersion(message.getAggregateId(), CONSUMER_NAME);
+//
+//                if (latestProcessed.isPresent() &&
+//                        latestProcessed.get().getEventVersion() >= eventVersion) {
+//                    log.debug("구 버전 이벤트 스킵 - eventId: {}", eventId);
+//                    continue;
+//                }
+//
+//                // 3. 이벤트 처리
+//                switch (message.getEventType()) {
+//                    case EventTypes.LIKE_ADDED -> handleLikeAdded(message);
+//                    case EventTypes.LIKE_REMOVED -> handleLikeRemoved(message);
+//                    case EventTypes.ORDER_CREATED -> handleOrderCreated(message);
+//                    case EventTypes.ORDER_CONFIRMED -> handleOrderConfirmed(message);
+//                    case EventTypes.ORDER_CANCELLED -> handleOrderCancelled(message);
+//                    case EventTypes.PAYMENT_COMPLETED -> handlePaymentCompleted(message);
+//                    case EventTypes.PAYMENT_FAILED -> handlePaymentFailed(message);
+//                    default -> log.debug("메트릭 처리 대상 아님 - type: {}", message.getEventType());
+//                }
+//
+//                // 4. 처리 완료 기록
+//                eventHandledRepository.save(
+//                        EventHandled.create(
+//                                eventId,
+//                                CONSUMER_NAME,
+//                                message.getEventType(),
+//                                message.getAggregateId(),
+//                                eventVersion
+//                        )
+//                );
+//
+//                processedCount++;
+//
+//            } catch (Exception e) {
+//                log.error("개별 메시지 처리 실패", e);
+//                failedCount++;
+//
+//                // DLQ로 전송
+//                dlqPublisher.sendToDlq(
+//                        topic,
+//                        messageJson,
+//                        CONSUMER_NAME,
+//                        e.getMessage()
+//                );
+//            }
+//        }
+//
+//        // 5. 배치 전체 ACK
+//        ack.acknowledge();
+//        log.info("배치 처리 완료 - 처리: {}/{} 건", processedCount, messages.size());
+//    }
 
     /**
      * 좋아요 추가 처리

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -103,6 +103,7 @@ public class MetricsConsumer {
                     case EventTypes.ORDER_CANCELLED -> handleOrderCancelled(message);
                     case "PaymentSuccessEvent" -> handlePaymentCompleted(message);
                     case "PaymentFailEvent" -> handlePaymentFailed(message);
+                    case "ProductViewEvent" -> handleProductView(message);
                     default -> log.debug("메트릭 처리 대상 아님 - type: {}", message.getEventType());
                 }
 
@@ -138,6 +139,34 @@ public class MetricsConsumer {
         log.info("배치 처리 완료 - 처리: {}/{} 건", processedCount, messages.size());
     }
 
+    private void handleProductView(KafkaEventMessage<?> message) {
+        CatalogEventPayload.View payload =
+                objectMapper.convertValue(message.getPayload(), CatalogEventPayload.View.class);
+
+        Long productId = payload.getProductId();
+        LocalDate today = LocalDate.now();
+
+        // 오늘 날짜의 메트릭 조회 or 생성
+        ProductMetrics metrics = productMetricsRepository
+                .findByProductIdAndMetricDate(productId, today)
+                .orElse(ProductMetrics.builder()
+                        .productId(productId)
+                        .metricDate(today)
+                        .likeCount(0L)
+                        .orderCount(0L)
+                        .salesQuantity(0L)
+                        .viewCount(0L)
+                        .updatedAt(LocalDateTime.now())
+                        .build());
+
+        // 조회 수 증가
+        metrics.view();
+
+        productMetricsRepository.save(metrics);
+        log.info("좋아요 메트릭 업데이트 - productId: {}, viewCount: {}",
+                productId, metrics.getViewCount());
+    }
+
     /**
      * 좋아요 추가 처리
      */
@@ -157,6 +186,7 @@ public class MetricsConsumer {
                         .likeCount(0L)
                         .orderCount(0L)
                         .salesQuantity(0L)
+                        .viewCount(0L)
                         .updatedAt(LocalDateTime.now())
                         .build());
 
@@ -186,6 +216,7 @@ public class MetricsConsumer {
                         .likeCount(0L)
                         .orderCount(0L)
                         .salesQuantity(0L)
+                        .viewCount(0L)
                         .updatedAt(LocalDateTime.now())
                         .build());
 
@@ -226,6 +257,7 @@ public class MetricsConsumer {
                             .likeCount(0L)
                             .orderCount(0L)
                             .salesQuantity(0L)
+                            .viewCount(0L)
                             .updatedAt(LocalDateTime.now())
                             .build());
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,15 +91,18 @@ public class MetricsConsumer {
                     continue;
                 }
 
+
+                log.info("이벤트 타입:   {}", message.getEventType());
+
                 // 3. 이벤트 처리
                 switch (message.getEventType()) {
-                    case EventTypes.LIKE_ADDED -> handleLikeAdded(message);
-                    case EventTypes.LIKE_REMOVED -> handleLikeRemoved(message);
-                    case EventTypes.ORDER_CREATED -> handleOrderCreated(message);
-                    case EventTypes.ORDER_CONFIRMED -> handleOrderConfirmed(message);
+                    case "LikeEvent" -> handleLikeAdded(message);
+                    case "DisLikeEvent" -> handleLikeRemoved(message);
+                    case "OrderCreatedEvent" -> handleOrderCreated(message);
+                    case "OrderCompletedEvent" -> handleOrderConfirmed(message);
                     case EventTypes.ORDER_CANCELLED -> handleOrderCancelled(message);
-                    case EventTypes.PAYMENT_COMPLETED -> handlePaymentCompleted(message);
-                    case EventTypes.PAYMENT_FAILED -> handlePaymentFailed(message);
+                    case "PaymentSuccessEvent" -> handlePaymentCompleted(message);
+                    case "PaymentFailEvent" -> handlePaymentFailed(message);
                     default -> log.debug("메트릭 처리 대상 아님 - type: {}", message.getEventType());
                 }
 
@@ -134,108 +138,6 @@ public class MetricsConsumer {
         log.info("배치 처리 완료 - 처리: {}/{} 건", processedCount, messages.size());
     }
 
-
-//    @KafkaListener(
-//            topics = {KafkaTopics.CATALOG_EVENTS, KafkaTopics.ORDER_EVENTS},
-//            groupId = "metrics-batch-group",
-//            containerFactory = "BATCH_LISTENER_DEFAULT"
-//    )
-//    @Transactional
-//    public void consumeBatch(
-//            List<String> messages,
-//            @Header(KafkaHeaders.RECEIVED_TOPIC) List<String> topics,
-//            Acknowledgment ack
-//    ) {
-//        log.info("배치 처리 시작 - {} 건", messages.size());
-//
-//        int processedCount = 0;
-//        int failedCount = 0;
-//
-//        for (int i = 0; i < messages.size(); i++) {
-//            String messageJson = messages.get(i);
-//            String topic = topics.get(i);  // 같은 인덱스의 토픽
-//
-//            if (messageJson == null || messageJson.isEmpty()) {
-//                log.warn("빈 메시지 스킵");
-//                continue;
-//            }
-//
-//            try {
-//                // JSON 파싱
-//                KafkaEventMessage<?> message = objectMapper.readValue(
-//                        messageJson,
-//                        objectMapper.getTypeFactory().constructParametricType(
-//                                KafkaEventMessage.class,
-//                                Object.class
-//                        )
-//                );
-//
-//                String eventId = message.getEventId();
-//
-//                // 1. 멱등성 체크
-//                if (eventHandledRepository.existsByEventIdAndConsumerName(eventId, CONSUMER_NAME)) {
-//                    log.debug("이미 처리된 이벤트 스킵 - eventId: {}", eventId);
-//                    continue;
-//                }
-//
-//                // 2. Version 체크
-//                Long eventVersion = message.getVersion() != null
-//                        ? message.getVersion().longValue()
-//                        : System.currentTimeMillis() / 1000;
-//
-//                Optional<EventHandled> latestProcessed = eventHandledRepository
-//                        .findLatestVersion(message.getAggregateId(), CONSUMER_NAME);
-//
-//                if (latestProcessed.isPresent() &&
-//                        latestProcessed.get().getEventVersion() >= eventVersion) {
-//                    log.debug("구 버전 이벤트 스킵 - eventId: {}", eventId);
-//                    continue;
-//                }
-//
-//                // 3. 이벤트 처리
-//                switch (message.getEventType()) {
-//                    case EventTypes.LIKE_ADDED -> handleLikeAdded(message);
-//                    case EventTypes.LIKE_REMOVED -> handleLikeRemoved(message);
-//                    case EventTypes.ORDER_CREATED -> handleOrderCreated(message);
-//                    case EventTypes.ORDER_CONFIRMED -> handleOrderConfirmed(message);
-//                    case EventTypes.ORDER_CANCELLED -> handleOrderCancelled(message);
-//                    case EventTypes.PAYMENT_COMPLETED -> handlePaymentCompleted(message);
-//                    case EventTypes.PAYMENT_FAILED -> handlePaymentFailed(message);
-//                    default -> log.debug("메트릭 처리 대상 아님 - type: {}", message.getEventType());
-//                }
-//
-//                // 4. 처리 완료 기록
-//                eventHandledRepository.save(
-//                        EventHandled.create(
-//                                eventId,
-//                                CONSUMER_NAME,
-//                                message.getEventType(),
-//                                message.getAggregateId(),
-//                                eventVersion
-//                        )
-//                );
-//
-//                processedCount++;
-//
-//            } catch (Exception e) {
-//                log.error("개별 메시지 처리 실패", e);
-//                failedCount++;
-//
-//                // DLQ로 전송
-//                dlqPublisher.sendToDlq(
-//                        topic,
-//                        messageJson,
-//                        CONSUMER_NAME,
-//                        e.getMessage()
-//                );
-//            }
-//        }
-//
-//        // 5. 배치 전체 ACK
-//        ack.acknowledge();
-//        log.info("배치 처리 완료 - 처리: {}/{} 건", processedCount, messages.size());
-//    }
-
     /**
      * 좋아요 추가 처리
      */
@@ -255,6 +157,7 @@ public class MetricsConsumer {
                         .likeCount(0L)
                         .orderCount(0L)
                         .salesQuantity(0L)
+                        .updatedAt(LocalDateTime.now())
                         .build());
 
         // 좋아요 수 증가
@@ -283,6 +186,7 @@ public class MetricsConsumer {
                         .likeCount(0L)
                         .orderCount(0L)
                         .salesQuantity(0L)
+                        .updatedAt(LocalDateTime.now())
                         .build());
 
         metrics.removeLike();
@@ -296,10 +200,19 @@ public class MetricsConsumer {
      * 주문 생성 처리
      */
     private void handleOrderCreated(KafkaEventMessage<?> message) {
+        log.info("주문 메트릭 처리 - aggregateId: {}", message.getAggregateId());
+    }
+
+    /**
+     * 주문 확정 처리
+     */
+    private void handleOrderConfirmed(KafkaEventMessage<?> message) {
+
         OrderEventPayload.OrderCreated payload =
                 objectMapper.convertValue(message.getPayload(), OrderEventPayload.OrderCreated.class);
 
         LocalDate today = LocalDate.now();
+        log.info("주문 생성 처리");
 
         // 주문의 각 상품별로 처리
         for (OrderEventPayload.OrderItem item : payload.getOrderItems()) {
@@ -313,6 +226,7 @@ public class MetricsConsumer {
                             .likeCount(0L)
                             .orderCount(0L)
                             .salesQuantity(0L)
+                            .updatedAt(LocalDateTime.now())
                             .build());
 
             // 주문 수와 판매량 증가
@@ -322,12 +236,6 @@ public class MetricsConsumer {
             log.info("주문 메트릭 업데이트 - productId: {}, orderCount: {}, salesQty: {}",
                     productId, metrics.getOrderCount(), metrics.getSalesQuantity());
         }
-    }
-
-    /**
-     * 주문 확정 처리
-     */
-    private void handleOrderConfirmed(KafkaEventMessage<?> message) {
         log.info("주문 확정 이벤트 처리 - aggregateId: {}", message.getAggregateId());
     }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -5,6 +5,7 @@ import com.loopers.domain.event.EventHandled;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.ProductMetrics;
 import com.loopers.domain.metrics.ProductMetricsRepository;
+import com.loopers.domain.ranking.RankingService;
 import com.loopers.kafka.EventTypes;
 import com.loopers.kafka.KafkaTopics;
 import com.loopers.kafka.message.KafkaEventMessage;
@@ -39,6 +40,7 @@ public class MetricsConsumer {
     private final EventHandledRepository eventHandledRepository;
     private final ObjectMapper objectMapper;
     private final com.loopers.support.DlqPublisher dlqPublisher;
+    private final RankingService rankingService;
 
 
     @KafkaListener(
@@ -96,14 +98,26 @@ public class MetricsConsumer {
 
                 // 3. 이벤트 처리
                 switch (message.getEventType()) {
-                    case "LikeEvent" -> handleLikeAdded(message);
-                    case "DisLikeEvent" -> handleLikeRemoved(message);
+                    case "LikeEvent" -> {
+                        handleLikeAdded(message);
+                        rankingService.addLikeScore(message);
+                    }
+                    case "DisLikeEvent" -> {
+                        handleLikeRemoved(message);
+                        rankingService.removeLikeScore(message);
+                    }
                     case "OrderCreatedEvent" -> handleOrderCreated(message);
-                    case "OrderCompletedEvent" -> handleOrderConfirmed(message);
+                    case "OrderCompletedEvent" -> {
+                        handleOrderConfirmed(message);
+                        rankingService.addOrderScore(message);
+                    }
                     case EventTypes.ORDER_CANCELLED -> handleOrderCancelled(message);
                     case "PaymentSuccessEvent" -> handlePaymentCompleted(message);
                     case "PaymentFailEvent" -> handlePaymentFailed(message);
-                    case "ProductViewEvent" -> handleProductView(message);
+                    case "ProductViewEvent" -> {
+                        handleProductView(message);
+                        rankingService.addViewScore(message);
+                    }
                     default -> log.debug("메트릭 처리 대상 아님 - type: {}", message.getEventType());
                 }
 

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -70,7 +70,7 @@ services:
       - KAFKA_CFG_PROCESS_ROLES=broker,controller # KRaft 모드여서, broker / controller 역할 모두 부여
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:19092,CONTROLLER://:9093
       # 브로커 클라이언트 (PLAINTEXT), 브로커 호스트 (PLAINTEXT) 내부 컨트롤러 (CONTROLLER)
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092,PLAINTEXT_HOST://localhost:19092
       # 외부 클라이언트 접속 호스트 (localhost:9092), 브로커 접속 호스트 (localhost:19092)
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
       # 각 리스너별 보안 프로토콜 설정
@@ -83,7 +83,7 @@ services:
     volumes:
       - kafka-data:/bitnami/kafka
     healthcheck:
-      test: [ "CMD", "bash", "-c", "kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1" ]
+      test: [ "CMD", "bash", "-c", "kafka-topics.sh --bootstrap-server localhost:19092 --list || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -98,7 +98,7 @@ services:
       - "9090:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local  # kafka-ui 에서 보이는 클러스터명
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092 # kafka-ui 가 연겷할 브로커 주소
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: localhost:19092 # kafka-ui 가 연겷할 브로커 주소
 
 volumes:
   mysql-8-data:

--- a/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
@@ -1,7 +1,10 @@
-package com.loopers.confg.kafka;
+package com.loopers.config.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +14,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +35,12 @@ public class KafkaConfig {
     @Bean
     public ProducerFactory<Object, Object> producerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
+
+        // 명시적으로 JsonSerializer 설정
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
+
         return new DefaultKafkaProducerFactory<>(props);
     }
 
@@ -80,4 +90,27 @@ public class KafkaConfig {
         // MessageConverter 설정하지 않음
         return factory;
     }
+
+    @Bean("dlqStringListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, String> dlqStringListenerContainerFactory(
+            KafkaProperties kafkaProperties
+    ) {
+        Map<String, Object> consumerConfig = new HashMap<>(kafkaProperties.buildConsumerProperties());
+
+        // DLQ는 String Deserializer 사용
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        DefaultKafkaConsumerFactory<String, String> consumerFactory =
+                new DefaultKafkaConsumerFactory<>(consumerConfig);
+
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+
+        return factory;
+    }
+
+
 }

--- a/modules/kafka/src/main/java/com/loopers/kafka/message/payload/CatalogEventPayload.java
+++ b/modules/kafka/src/main/java/com/loopers/kafka/message/payload/CatalogEventPayload.java
@@ -18,6 +18,20 @@ public class CatalogEventPayload {
     }
 
     /**
+     * 상품 조회 이벤트 페이로드
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class View {
+        private Long productId;
+        private String userId;
+        private LocalDateTime createdAt;
+    }
+
+
+    /**
      * 좋아요 추가 이벤트 페이로드
      */
     @Getter

--- a/modules/kafka/src/main/java/com/loopers/kafka/message/payload/OrderEventPayload.java
+++ b/modules/kafka/src/main/java/com/loopers/kafka/message/payload/OrderEventPayload.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,9 +26,11 @@ public class OrderEventPayload {
     @AllArgsConstructor
     @Builder
     public static class OrderCreated {
+
         private Long orderId;
         private String userId;
-        private BigDecimal totalAmount;
+        private String orderUuid;
+        private Long totalAmount;
         private List<OrderItem> orderItems;
         private LocalDateTime createdAt;
     }
@@ -70,7 +71,7 @@ public class OrderEventPayload {
     @Builder
     public static class OrderItem {
         private Long productId;
-        private Integer quantity;
-        private BigDecimal price;
+        private Long quantity;
+        private Long price;
     }
 }

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -18,9 +18,10 @@ spring:
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-serializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         enable-auto-commit: false
+        spring.json.trusted.packages: "*"
     listener:
       ack-mode: manual
 
@@ -29,10 +30,10 @@ spring.config.activate.on-profile: local, test
 
 spring:
   kafka:
-    bootstrap-servers: localhost:19092
+    bootstrap-servers: localhost:9092
     admin:
       properties:
-        bootstrap.servers: kafka:9092
+        bootstrap.servers: localhost:9092
 
 ---
 spring.config.activate.on-profile: dev


### PR DESCRIPTION
## 📌 Summary
- 카프카 적용
- 상품 조회, 좋아요, 좋아요 취소, 주문 시 product_metrics 업데이트 (kafka)
- 이벤트 발생 시 랭킹 점수 업데이트 (kafka)
- 랭킹 점수를 redis에 추가하여 랭킹 시스템 도입 (일자별)
- 랭킹 리스트 조회 api 추가 `/api/v1/rankings?date=yyyyMMdd&size=20&page=1`

## 💬 Review Points
1. 현재 product_metrics 에 데이터를 업데이트 하는 동시에 랭킹 점수도 업데이트 동작 하도록 구현하였습니다. 제가 궁금한 점은 주문 취소 등의 이벤트에 따라서 랭킹점수도 내려가야 할까요 ? 주문 성공 시 해당 상품의 인기도를 증가시키는 것은 이해가 가는데, 주문을 하려고 했는데 잔액 부족 등으로 주문이 취소되는 경우에는 랭킹이 떨어져야하는지 궁금합니다.
2. redis에 저는 상품 id 만 저장한 후에 해당 id를 이용하여 상품을 조회하도록 구성하였습니다. 그리고 각 일자와 상품 id를 이용하여 랭킹 순위와 점수를 가져오도록 하였습니다. 만일 상품 리스트인 경우에는 redis 에 여러번 접근하여 정보를 가져오는게 맞을지, 아니면 id만이 아니라 상품 정보 등도 함께 저장하여 한번에 순위와 점수를 가져오도록 해야할 지 궁금합니다. 저는 redis는 전역변수라고 이해하여 그다지 비용이 들지 않을 것이라 생각하는데 실무에 들어가면 다를까요 ?
3. 우선 체크리스트 내 todo는 모두 구성하였습니다. 점수 반영이나 랭킹 정보 반환 등을 모두 정상작동함을 확인하였습니다...ㅎ
아래와 같은 식으로 저장이 되고 있습니다. 2번과 비슷한 질문이지만 실무에서도 redis 에 순위를 저장할 때 저런 방식으로 저장하나요 ?
<img width="534" height="292" alt="스크린샷 2025-09-12 오전 1 10 20" src="https://github.com/user-attachments/assets/34dd4327-afe5-44e7-a045-5ff04caeebd0" />

## ✅ Checklist
### 📈 Ranking Consumer
- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API
- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)
